### PR TITLE
feat(llm): add OpenRouter as LLM provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bonap",
-  "version": "1.0.47",
+  "version": "1.0.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bonap",
-      "version": "1.0.47",
+      "version": "1.0.50",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
@@ -75,7 +75,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1867,7 +1866,6 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1877,7 +1875,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1888,7 +1885,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1934,7 +1930,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2171,7 +2166,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2508,7 +2502,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3191,7 +3184,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5953,7 +5945,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5991,7 +5982,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6071,7 +6061,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6081,7 +6070,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6997,7 +6985,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7261,7 +7248,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7475,7 +7461,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/infrastructure/llm/AssistantService.ts
+++ b/src/infrastructure/llm/AssistantService.ts
@@ -4,8 +4,8 @@
  * Streaming + tools are implemented for Anthropic (primary).
  * Other providers fall back to a single non-streaming call with JSON-based actions.
  */
-import { llmConfigService } from "./LLMConfigService.ts"
-import type { LLMConfig } from "../../shared/types/llm.ts"
+import { llmConfigService } from './LLMConfigService.ts'
+import type { LLMConfig } from '../../shared/types/llm.ts'
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -16,19 +16,19 @@ export interface AssistantTool {
 }
 
 export type StreamEvent =
-  | { type: "text"; text: string }
-  | { type: "tool_start"; name: string }
-  | { type: "tool_result"; name: string; result: string }
-  | { type: "done" }
-  | { type: "error"; message: string }
+  | { type: 'text'; text: string }
+  | { type: 'tool_start'; name: string }
+  | { type: 'tool_result'; name: string; result: string }
+  | { type: 'done' }
+  | { type: 'error'; message: string }
 
 export interface AnthropicMessage {
-  role: "user" | "assistant"
+  role: 'user' | 'assistant'
   content: string | AnthropicContentBlock[]
 }
 
 export interface AnthropicContentBlock {
-  type: "text" | "tool_use" | "tool_result"
+  type: 'text' | 'tool_use' | 'tool_result'
   text?: string
   id?: string
   name?: string
@@ -42,42 +42,63 @@ export interface AnthropicContentBlock {
 
 const ANTHROPIC_TOOLS = [
   {
-    name: "search_recipe",
-    description: "Recherche des recettes par nom ou mots-clés dans la bibliothèque Mealie.",
+    name: 'search_recipe',
+    description:
+      'Recherche des recettes par nom ou mots-clés dans la bibliothèque Mealie.',
     input_schema: {
-      type: "object",
+      type: 'object',
       properties: {
-        query: { type: "string", description: "Terme de recherche" },
+        query: { type: 'string', description: 'Terme de recherche' },
       },
-      required: ["query"],
+      required: ['query'],
     },
   },
   {
-    name: "add_to_planning",
+    name: 'add_to_planning',
     description: "Ajoute une recette au planning de l'utilisateur.",
     input_schema: {
-      type: "object",
+      type: 'object',
       properties: {
-        recipe_slug: { type: "string", description: "Slug exact de la recette" },
-        recipe_id: { type: "string", description: "ID exact de la recette" },
-        date: { type: "string", description: "Date au format YYYY-MM-DD (optionnel, prochain créneau libre si absent)" },
-        entry_type: { type: "string", enum: ["lunch", "dinner"], description: "Déjeuner ou dîner" },
+        recipe_slug: {
+          type: 'string',
+          description: 'Slug exact de la recette',
+        },
+        recipe_id: { type: 'string', description: 'ID exact de la recette' },
+        date: {
+          type: 'string',
+          description:
+            'Date au format YYYY-MM-DD (optionnel, prochain créneau libre si absent)',
+        },
+        entry_type: {
+          type: 'string',
+          enum: ['lunch', 'dinner'],
+          description: 'Déjeuner ou dîner',
+        },
       },
-      required: ["recipe_id"],
+      required: ['recipe_id'],
     },
   },
   {
-    name: "create_recipe",
-    description: "Crée une nouvelle recette dans Mealie et propose de l'enregistrer.",
+    name: 'create_recipe',
+    description:
+      "Crée une nouvelle recette dans Mealie et propose de l'enregistrer.",
     input_schema: {
-      type: "object",
+      type: 'object',
       properties: {
-        name: { type: "string" },
-        description: { type: "string" },
-        ingredients: { type: "array", items: { type: "string" }, description: "Liste d'ingrédients en texte libre" },
-        instructions: { type: "array", items: { type: "string" }, description: "Étapes de la recette" },
+        name: { type: 'string' },
+        description: { type: 'string' },
+        ingredients: {
+          type: 'array',
+          items: { type: 'string' },
+          description: "Liste d'ingrédients en texte libre",
+        },
+        instructions: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Étapes de la recette',
+        },
       },
-      required: ["name"],
+      required: ['name'],
     },
   },
 ]
@@ -97,21 +118,28 @@ export async function sendAssistantMessage(
 ): Promise<void> {
   const config = llmConfigService.load()
   if (!llmConfigService.isConfigured()) {
-    onEvent({ type: "error", message: "Aucun fournisseur IA configuré. Rendez-vous dans les Paramètres." })
-    onEvent({ type: "done" })
+    onEvent({
+      type: 'error',
+      message:
+        'Aucun fournisseur IA configuré. Rendez-vous dans les Paramètres.',
+    })
+    onEvent({ type: 'done' })
     return
   }
 
   try {
-    if (config.provider === "anthropic") {
+    if (config.provider === 'anthropic') {
       await streamAnthropic(config, history, tools, onEvent)
     } else {
       await chatFallback(config, history, onEvent)
     }
   } catch (e) {
-    onEvent({ type: "error", message: e instanceof Error ? e.message : "Erreur inconnue" })
+    onEvent({
+      type: 'error',
+      message: e instanceof Error ? e.message : 'Erreur inconnue',
+    })
   } finally {
-    onEvent({ type: "done" })
+    onEvent({ type: 'done' })
   }
 }
 
@@ -123,13 +151,13 @@ async function streamAnthropic(
   tools: Record<string, AssistantTool>,
   onEvent: (event: StreamEvent) => void,
 ): Promise<void> {
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
     headers: {
-      "x-api-key": config.apiKey,
-      "anthropic-version": "2023-06-01",
-      "anthropic-dangerous-direct-browser-access": "true",
-      "content-type": "application/json",
+      'x-api-key': config.apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+      'content-type': 'application/json',
     },
     body: JSON.stringify({
       model: config.model,
@@ -145,14 +173,19 @@ async function streamAnthropic(
     throw new Error(`Anthropic ${res.status}: ${msg}`)
   }
 
-  const { textBlocks, toolUseBlocks } = await readAnthropicStream(res.body, onEvent)
+  const { textBlocks, toolUseBlocks } = await readAnthropicStream(
+    res.body,
+    onEvent,
+  )
 
   // If there are tool calls, execute them and loop
   if (toolUseBlocks.length > 0) {
     const assistantMessage: AnthropicMessage = {
-      role: "assistant",
+      role: 'assistant',
       content: [
-        ...textBlocks.map((t): AnthropicContentBlock => ({ type: "text", text: t })),
+        ...textBlocks.map(
+          (t): AnthropicContentBlock => ({ type: 'text', text: t }),
+        ),
         ...toolUseBlocks,
       ],
     }
@@ -160,24 +193,32 @@ async function streamAnthropic(
     const toolResults: AnthropicContentBlock[] = []
     for (const block of toolUseBlocks) {
       const toolName = block.name!
-      onEvent({ type: "tool_start", name: toolName })
-      let result = ""
+      onEvent({ type: 'tool_start', name: toolName })
+      let result = ''
       const impl = tools[toolName]
       if (impl) {
         result = await impl.execute(block.input ?? {})
       } else {
         result = `Outil "${toolName}" non disponible.`
       }
-      onEvent({ type: "tool_result", name: toolName, result })
+      onEvent({ type: 'tool_result', name: toolName, result })
       toolResults.push({
-        type: "tool_result",
+        type: 'tool_result',
         tool_use_id: block.id,
         content: result,
       })
     }
 
-    const userToolResult: AnthropicMessage = { role: "user", content: toolResults }
-    await streamAnthropic(config, [...history, assistantMessage, userToolResult], tools, onEvent)
+    const userToolResult: AnthropicMessage = {
+      role: 'user',
+      content: toolResults,
+    }
+    await streamAnthropic(
+      config,
+      [...history, assistantMessage, userToolResult],
+      tools,
+      onEvent,
+    )
   }
 }
 
@@ -200,24 +241,32 @@ async function readAnthropicStream(
   }
   const blockStates = new Map<number, BlockState>()
 
-  let buffer = ""
+  let buffer = ''
 
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
 
     buffer += decoder.decode(value, { stream: true })
-    const lines = buffer.split("\n")
-    buffer = lines.pop() ?? ""
+    const lines = buffer.split('\n')
+    buffer = lines.pop() ?? ''
 
     for (const line of lines) {
-      if (!line.startsWith("data: ")) continue
+      if (!line.startsWith('data: ')) continue
       const raw = line.slice(6).trim()
-      if (!raw || raw === "[DONE]") continue
+      if (!raw || raw === '[DONE]') continue
       try {
         const evt = JSON.parse(raw) as Record<string, unknown>
-        handleAnthropicEvent(evt, blockStates, textBlocks, toolUseBlocks, onEvent)
-      } catch { /* ignore malformed lines */ }
+        handleAnthropicEvent(
+          evt,
+          blockStates,
+          textBlocks,
+          toolUseBlocks,
+          onEvent,
+        )
+      } catch {
+        /* ignore malformed lines */
+      }
     }
   }
 
@@ -226,45 +275,63 @@ async function readAnthropicStream(
 
 function handleAnthropicEvent(
   evt: Record<string, unknown>,
-  blockStates: Map<number, { type: string; id?: string; name?: string; inputJson: string; text: string }>,
+  blockStates: Map<
+    number,
+    {
+      type: string
+      id?: string
+      name?: string
+      inputJson: string
+      text: string
+    }
+  >,
   textBlocks: string[],
   toolUseBlocks: AnthropicContentBlock[],
   onEvent: (event: StreamEvent) => void,
 ) {
-  if (evt.type === "content_block_start") {
+  if (evt.type === 'content_block_start') {
     const index = evt.index as number
     const block = evt.content_block as Record<string, unknown>
     blockStates.set(index, {
       type: block.type as string,
       id: block.id as string | undefined,
       name: block.name as string | undefined,
-      inputJson: "",
-      text: "",
+      inputJson: '',
+      text: '',
     })
-  } else if (evt.type === "content_block_delta") {
+  } else if (evt.type === 'content_block_delta') {
     const index = evt.index as number
     const delta = evt.delta as Record<string, unknown>
     const state = blockStates.get(index)
     if (!state) return
 
-    if (delta.type === "text_delta") {
+    if (delta.type === 'text_delta') {
       const text = delta.text as string
       state.text += text
-      onEvent({ type: "text", text })
-    } else if (delta.type === "input_json_delta") {
+      onEvent({ type: 'text', text })
+    } else if (delta.type === 'input_json_delta') {
       state.inputJson += delta.partial_json as string
     }
-  } else if (evt.type === "content_block_stop") {
+  } else if (evt.type === 'content_block_stop') {
     const index = evt.index as number
     const state = blockStates.get(index)
     if (!state) return
 
-    if (state.type === "text") {
+    if (state.type === 'text') {
       textBlocks.push(state.text)
-    } else if (state.type === "tool_use") {
+    } else if (state.type === 'tool_use') {
       let input: Record<string, unknown> = {}
-      try { input = JSON.parse(state.inputJson) as Record<string, unknown> } catch { /* empty input */ }
-      toolUseBlocks.push({ type: "tool_use", id: state.id, name: state.name, input })
+      try {
+        input = JSON.parse(state.inputJson) as Record<string, unknown>
+      } catch {
+        /* empty input */
+      }
+      toolUseBlocks.push({
+        type: 'tool_use',
+        id: state.id,
+        name: state.name,
+        input,
+      })
     }
   }
 }
@@ -278,56 +345,70 @@ async function chatFallback(
 ): Promise<void> {
   const messages = history.map((m) => ({
     role: m.role,
-    content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+    content:
+      typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
   }))
 
-  let text = ""
+  let text = ''
 
-  if (config.provider === "openai" || config.provider === "mistral" || config.provider === "perplexity") {
+  if (
+    config.provider === 'openai' ||
+    config.provider === 'mistral' ||
+    config.provider === 'perplexity' ||
+    config.provider === 'openrouter'
+  ) {
     const endpoints: Record<string, string> = {
-      openai: "https://api.openai.com/v1/chat/completions",
-      mistral: "https://api.mistral.ai/v1/chat/completions",
-      perplexity: "https://api.perplexity.ai/chat/completions",
+      openai: 'https://api.openai.com/v1/chat/completions',
+      mistral: 'https://api.mistral.ai/v1/chat/completions',
+      perplexity: 'https://api.perplexity.ai/chat/completions',
+      openrouter: 'https://openrouter.ai/api/v1/chat/completions',
     }
     const res = await fetch(endpoints[config.provider], {
-      method: "POST",
-      headers: { Authorization: `Bearer ${config.apiKey}`, "content-type": "application/json" },
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'content-type': 'application/json',
+      },
       body: JSON.stringify({ model: config.model, messages }),
     })
     if (!res.ok) throw new Error(`${config.provider} ${res.status}`)
-    const data = await res.json() as { choices: Array<{ message: { content: string } }> }
-    text = data.choices[0]?.message.content ?? ""
-  } else if (config.provider === "google") {
+    const data = (await res.json()) as {
+      choices: Array<{ message: { content: string } }>
+    }
+    text = data.choices[0]?.message.content ?? ''
+  } else if (config.provider === 'google') {
     // Gemini attend role "user"/"model" (pas "assistant"), et l'API supporte CORS directement
     const contents = messages.map((m) => ({
-      role: m.role === "assistant" ? "model" : "user",
+      role: m.role === 'assistant' ? 'model' : 'user',
       parts: [{ text: m.content }],
     }))
     const res = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/${config.model}:generateContent?key=${config.apiKey}`,
       {
-        method: "POST",
-        headers: { "content-type": "application/json" },
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ contents }),
       },
     )
     if (!res.ok) throw new Error(`Google ${res.status}`)
-    const data = await res.json() as { candidates: Array<{ content: { parts: Array<{ text: string }> } }> }
-    text = data.candidates[0]?.content.parts[0]?.text ?? ""
-  } else if (config.provider === "ollama") {
-    const base = config.ollamaBaseUrl.replace(/\/+$/, "")
+    const data = (await res.json()) as {
+      candidates: Array<{ content: { parts: Array<{ text: string }> } }>
+    }
+    text = data.candidates[0]?.content.parts[0]?.text ?? ''
+  } else if (config.provider === 'ollama') {
+    const base = config.ollamaBaseUrl.replace(/\/+$/, '')
     const res = await fetch(`${base}/api/chat`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ model: config.model, stream: false, messages }),
     })
     if (!res.ok) throw new Error(`Ollama ${res.status}`)
-    const data = await res.json() as { message: { content: string } }
-    text = data.message?.content ?? ""
+    const data = (await res.json()) as { message: { content: string } }
+    text = data.message?.content ?? ''
   }
 
   // Emit text as a single chunk (simulated streaming)
-  for (const word of text.split(" ")) {
-    onEvent({ type: "text", text: (word ? word + " " : "") })
+  for (const word of text.split(' ')) {
+    onEvent({ type: 'text', text: word ? word + ' ' : '' })
   }
 }

--- a/src/infrastructure/llm/LLMConfigService.ts
+++ b/src/infrastructure/llm/LLMConfigService.ts
@@ -1,7 +1,7 @@
-import type { LLMConfig, LLMProvider } from "../../shared/types/llm.ts"
-import { DEFAULT_LLM_CONFIG } from "../../shared/types/llm.ts"
+import type { LLMConfig, LLMProvider } from '../../shared/types/llm.ts'
+import { DEFAULT_LLM_CONFIG } from '../../shared/types/llm.ts'
 
-const STORAGE_KEY = "bonap_llm_config"
+const STORAGE_KEY = 'bonap_llm_config'
 
 function getEnvOverrides(): Partial<LLMConfig> {
   const env = window.__ENV__
@@ -17,10 +17,10 @@ function getEnvOverrides(): Partial<LLMConfig> {
 export function getLLMEnvFields(): Set<keyof LLMConfig> {
   const env = window.__ENV__
   const fields = new Set<keyof LLMConfig>()
-  if (env?.LLM_PROVIDER) fields.add("provider")
-  if (env?.LLM_API_KEY) fields.add("apiKey")
-  if (env?.LLM_MODEL) fields.add("model")
-  if (env?.LLM_OLLAMA_URL) fields.add("ollamaBaseUrl")
+  if (env?.LLM_PROVIDER) fields.add('provider')
+  if (env?.LLM_API_KEY) fields.add('apiKey')
+  if (env?.LLM_MODEL) fields.add('model')
+  if (env?.LLM_OLLAMA_URL) fields.add('ollamaBaseUrl')
   return fields
 }
 
@@ -29,7 +29,11 @@ export class LLMConfigService {
     try {
       const raw = localStorage.getItem(STORAGE_KEY)
       const stored = raw ? (JSON.parse(raw) as Partial<LLMConfig>) : {}
-      return { ...DEFAULT_LLM_CONFIG, ...stored, ...getEnvOverrides() } as LLMConfig
+      return {
+        ...DEFAULT_LLM_CONFIG,
+        ...stored,
+        ...getEnvOverrides(),
+      } as LLMConfig
     } catch {
       return { ...DEFAULT_LLM_CONFIG, ...getEnvOverrides() } as LLMConfig
     }
@@ -45,91 +49,130 @@ export class LLMConfigService {
 
   isConfigured(): boolean {
     const config = this.load()
-    if (config.provider === "ollama") return Boolean(config.ollamaBaseUrl)
+    if (config.provider === 'ollama') return Boolean(config.ollamaBaseUrl)
     return Boolean(config.apiKey)
   }
 
-  async testConnection(config: LLMConfig): Promise<{ ok: boolean; message: string }> {
+  async testConnection(
+    config: LLMConfig,
+  ): Promise<{ ok: boolean; message: string }> {
     try {
       switch (config.provider) {
-        case "anthropic":
+        case 'anthropic':
           return await testAnthropic(config.apiKey, config.model)
-        case "openai":
+        case 'openai':
           return await testOpenAI(config.apiKey, config.model)
-        case "google":
+        case 'google':
           return await testGoogle(config.apiKey, config.model)
-        case "ollama":
+        case 'ollama':
           return await testOllama(config.ollamaBaseUrl)
+        case 'openrouter':
+          return await testOpenRouter(config.apiKey, config.model)
         default:
-          return { ok: false, message: "Fournisseur inconnu" }
+          return { ok: false, message: 'Fournisseur inconnu' }
       }
     } catch (e) {
-      return { ok: false, message: e instanceof Error ? e.message : "Erreur inconnue" }
+      return {
+        ok: false,
+        message: e instanceof Error ? e.message : 'Erreur inconnue',
+      }
     }
   }
 }
 
-async function testAnthropic(apiKey: string, model: string): Promise<{ ok: boolean; message: string }> {
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
+async function testAnthropic(
+  apiKey: string,
+  model: string,
+): Promise<{ ok: boolean; message: string }> {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
     headers: {
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-      "anthropic-dangerous-direct-browser-access": "true",
-      "content-type": "application/json",
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+      'content-type': 'application/json',
     },
     body: JSON.stringify({
       model,
       max_tokens: 1,
-      messages: [{ role: "user", content: "Hi" }],
+      messages: [{ role: 'user', content: 'Hi' }],
     }),
   })
-  if (res.ok || res.status === 400) return { ok: true, message: "Clé valide" }
-  if (res.status === 401) return { ok: false, message: "Clé invalide (401)" }
+  if (res.ok || res.status === 400) return { ok: true, message: 'Clé valide' }
+  if (res.status === 401) return { ok: false, message: 'Clé invalide (401)' }
   return { ok: false, message: `Erreur ${res.status}` }
 }
 
-async function testOpenAI(apiKey: string, model: string): Promise<{ ok: boolean; message: string }> {
-  const res = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
+async function testOpenAI(
+  apiKey: string,
+  model: string,
+): Promise<{ ok: boolean; message: string }> {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${apiKey}`,
-      "content-type": "application/json",
+      'content-type': 'application/json',
     },
     body: JSON.stringify({
       model,
       max_tokens: 1,
-      messages: [{ role: "user", content: "Hi" }],
+      messages: [{ role: 'user', content: 'Hi' }],
     }),
   })
-  if (res.ok || res.status === 400) return { ok: true, message: "Clé valide" }
-  if (res.status === 401) return { ok: false, message: "Clé invalide (401)" }
+  if (res.ok || res.status === 400) return { ok: true, message: 'Clé valide' }
+  if (res.status === 401) return { ok: false, message: 'Clé invalide (401)' }
   return { ok: false, message: `Erreur ${res.status}` }
 }
 
-async function testGoogle(apiKey: string, model: string): Promise<{ ok: boolean; message: string }> {
+async function testGoogle(
+  apiKey: string,
+  model: string,
+): Promise<{ ok: boolean; message: string }> {
   const res = await fetch(
     `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
     {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ contents: [{ parts: [{ text: "Hi" }] }] }),
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ contents: [{ parts: [{ text: 'Hi' }] }] }),
     },
   )
-  if (res.ok || res.status === 400) return { ok: true, message: "Clé valide" }
-  if (res.status === 400) return { ok: false, message: "Clé invalide (400)" }
-  if (res.status === 403) return { ok: false, message: "Clé invalide (403)" }
+  if (res.ok || res.status === 400) return { ok: true, message: 'Clé valide' }
+  if (res.status === 400) return { ok: false, message: 'Clé invalide (400)' }
+  if (res.status === 403) return { ok: false, message: 'Clé invalide (403)' }
   return { ok: false, message: `Erreur ${res.status}` }
 }
 
-async function testOllama(baseUrl: string): Promise<{ ok: boolean; message: string }> {
-  const url = baseUrl.replace(/\/+$/, "")
+async function testOllama(
+  baseUrl: string,
+): Promise<{ ok: boolean; message: string }> {
+  const url = baseUrl.replace(/\/+$/, '')
   const res = await fetch(`${url}/api/version`)
   if (res.ok) {
-    const data = await res.json() as { version?: string }
-    return { ok: true, message: `Ollama ${data.version ?? ""}` }
+    const data = (await res.json()) as { version?: string }
+    return { ok: true, message: `Ollama ${data.version ?? ''}` }
   }
   return { ok: false, message: `Impossible de joindre Ollama (${res.status})` }
+}
+
+async function testOpenRouter(
+  apiKey: string,
+  model: string,
+): Promise<{ ok: boolean; message: string }> {
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'Hi' }],
+    }),
+  })
+  if (res.ok || res.status === 400) return { ok: true, message: 'Clé valide' }
+  if (res.status === 401) return { ok: false, message: 'Clé invalide (401)' }
+  return { ok: false, message: `Erreur ${res.status}` }
 }
 
 export const llmConfigService = new LLMConfigService()

--- a/src/infrastructure/llm/LLMService.ts
+++ b/src/infrastructure/llm/LLMService.ts
@@ -1,69 +1,84 @@
-import { llmConfigService } from "./LLMConfigService.ts"
-import type { LLMConfig } from "../../shared/types/llm.ts"
+import { llmConfigService } from './LLMConfigService.ts'
+import type { LLMConfig } from '../../shared/types/llm.ts'
 
 /**
  * Sends a single chat turn to the configured LLM provider.
  * Returns the raw text of the assistant response.
  */
-export async function llmChat(systemPrompt: string, userMessage: string): Promise<string> {
+export async function llmChat(
+  systemPrompt: string,
+  userMessage: string,
+): Promise<string> {
   const config = llmConfigService.load()
   if (!llmConfigService.isConfigured()) {
-    throw new Error("Aucun fournisseur IA configuré. Rendez-vous dans les Paramètres.")
+    throw new Error(
+      'Aucun fournisseur IA configuré. Rendez-vous dans les Paramètres.',
+    )
   }
   switch (config.provider) {
-    case "anthropic":
+    case 'anthropic':
       return callAnthropic(config, systemPrompt, userMessage)
-    case "openai":
+    case 'openai':
       return callOpenAI(config, systemPrompt, userMessage)
-    case "google":
+    case 'google':
       return callGoogle(config, systemPrompt, userMessage)
-    case "mistral":
+    case 'mistral':
       return callMistral(config, systemPrompt, userMessage)
-    case "perplexity":
+    case 'perplexity':
       return callPerplexity(config, systemPrompt, userMessage)
-    case "ollama":
+    case 'openrouter':
+      return callOpenRouter(config, systemPrompt, userMessage)
+    case 'ollama':
       return callOllama(config, systemPrompt, userMessage)
     default:
-      throw new Error("Fournisseur IA inconnu")
+      throw new Error('Fournisseur IA inconnu')
   }
 }
 
-async function callAnthropic(config: LLMConfig, system: string, user: string): Promise<string> {
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
+async function callAnthropic(
+  config: LLMConfig,
+  system: string,
+  user: string,
+): Promise<string> {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
     headers: {
-      "x-api-key": config.apiKey,
-      "anthropic-version": "2023-06-01",
-      "anthropic-dangerous-direct-browser-access": "true",
-      "content-type": "application/json",
+      'x-api-key': config.apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+      'content-type': 'application/json',
     },
     body: JSON.stringify({
       model: config.model,
       max_tokens: 1024,
       system,
-      messages: [{ role: "user", content: user }],
+      messages: [{ role: 'user', content: user }],
     }),
   })
   if (!res.ok) {
     const err = await res.text().catch(() => res.statusText)
     throw new Error(`Anthropic ${res.status}: ${err}`)
   }
-  const data = await res.json() as { content: Array<{ text: string }> }
-  return data.content[0]?.text ?? ""
+  const data = (await res.json()) as { content: Array<{ text: string }> }
+  return data.content[0]?.text ?? ''
 }
 
-async function callOpenAI(config: LLMConfig, system: string, user: string): Promise<string> {
-  const res = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
+async function callOpenAI(
+  config: LLMConfig,
+  system: string,
+  user: string,
+): Promise<string> {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${config.apiKey}`,
-      "content-type": "application/json",
+      'content-type': 'application/json',
     },
     body: JSON.stringify({
       model: config.model,
       messages: [
-        { role: "system", content: system },
-        { role: "user", content: user },
+        { role: 'system', content: system },
+        { role: 'user', content: user },
       ],
     }),
   })
@@ -71,16 +86,22 @@ async function callOpenAI(config: LLMConfig, system: string, user: string): Prom
     const err = await res.text().catch(() => res.statusText)
     throw new Error(`OpenAI ${res.status}: ${err}`)
   }
-  const data = await res.json() as { choices: Array<{ message: { content: string } }> }
-  return data.choices[0]?.message.content ?? ""
+  const data = (await res.json()) as {
+    choices: Array<{ message: { content: string } }>
+  }
+  return data.choices[0]?.message.content ?? ''
 }
 
-async function callGoogle(config: LLMConfig, system: string, user: string): Promise<string> {
+async function callGoogle(
+  config: LLMConfig,
+  system: string,
+  user: string,
+): Promise<string> {
   const res = await fetch(
     `https://generativelanguage.googleapis.com/v1beta/models/${config.model}:generateContent?key=${config.apiKey}`,
     {
-      method: "POST",
-      headers: { "content-type": "application/json" },
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         systemInstruction: { parts: [{ text: system }] },
         contents: [{ parts: [{ text: user }] }],
@@ -91,22 +112,28 @@ async function callGoogle(config: LLMConfig, system: string, user: string): Prom
     const err = await res.text().catch(() => res.statusText)
     throw new Error(`Google ${res.status}: ${err}`)
   }
-  const data = await res.json() as { candidates: Array<{ content: { parts: Array<{ text: string }> } }> }
-  return data.candidates[0]?.content.parts[0]?.text ?? ""
+  const data = (await res.json()) as {
+    candidates: Array<{ content: { parts: Array<{ text: string }> } }>
+  }
+  return data.candidates[0]?.content.parts[0]?.text ?? ''
 }
 
-async function callMistral(config: LLMConfig, system: string, user: string): Promise<string> {
-  const res = await fetch("https://api.mistral.ai/v1/chat/completions", {
-    method: "POST",
+async function callMistral(
+  config: LLMConfig,
+  system: string,
+  user: string,
+): Promise<string> {
+  const res = await fetch('https://api.mistral.ai/v1/chat/completions', {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${config.apiKey}`,
-      "content-type": "application/json",
+      'content-type': 'application/json',
     },
     body: JSON.stringify({
       model: config.model,
       messages: [
-        { role: "system", content: system },
-        { role: "user", content: user },
+        { role: 'system', content: system },
+        { role: 'user', content: user },
       ],
     }),
   })
@@ -114,22 +141,28 @@ async function callMistral(config: LLMConfig, system: string, user: string): Pro
     const err = await res.text().catch(() => res.statusText)
     throw new Error(`Mistral ${res.status}: ${err}`)
   }
-  const data = await res.json() as { choices: Array<{ message: { content: string } }> }
-  return data.choices[0]?.message.content ?? ""
+  const data = (await res.json()) as {
+    choices: Array<{ message: { content: string } }>
+  }
+  return data.choices[0]?.message.content ?? ''
 }
 
-async function callPerplexity(config: LLMConfig, system: string, user: string): Promise<string> {
-  const res = await fetch("https://api.perplexity.ai/chat/completions", {
-    method: "POST",
+async function callPerplexity(
+  config: LLMConfig,
+  system: string,
+  user: string,
+): Promise<string> {
+  const res = await fetch('https://api.perplexity.ai/chat/completions', {
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${config.apiKey}`,
-      "content-type": "application/json",
+      'content-type': 'application/json',
     },
     body: JSON.stringify({
       model: config.model,
       messages: [
-        { role: "system", content: system },
-        { role: "user", content: user },
+        { role: 'system', content: system },
+        { role: 'user', content: user },
       ],
     }),
   })
@@ -137,21 +170,27 @@ async function callPerplexity(config: LLMConfig, system: string, user: string): 
     const err = await res.text().catch(() => res.statusText)
     throw new Error(`Perplexity ${res.status}: ${err}`)
   }
-  const data = await res.json() as { choices: Array<{ message: { content: string } }> }
-  return data.choices[0]?.message.content ?? ""
+  const data = (await res.json()) as {
+    choices: Array<{ message: { content: string } }>
+  }
+  return data.choices[0]?.message.content ?? ''
 }
 
-async function callOllama(config: LLMConfig, system: string, user: string): Promise<string> {
-  const base = config.ollamaBaseUrl.replace(/\/+$/, "")
+async function callOllama(
+  config: LLMConfig,
+  system: string,
+  user: string,
+): Promise<string> {
+  const base = config.ollamaBaseUrl.replace(/\/+$/, '')
   const res = await fetch(`${base}/api/chat`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       model: config.model,
       stream: false,
       messages: [
-        { role: "system", content: system },
-        { role: "user", content: user },
+        { role: 'system', content: system },
+        { role: 'user', content: user },
       ],
     }),
   })
@@ -159,6 +198,35 @@ async function callOllama(config: LLMConfig, system: string, user: string): Prom
     const err = await res.text().catch(() => res.statusText)
     throw new Error(`Ollama ${res.status}: ${err}`)
   }
-  const data = await res.json() as { message: { content: string } }
-  return data.message?.content ?? ""
+  const data = (await res.json()) as { message: { content: string } }
+  return data.message?.content ?? ''
+}
+
+async function callOpenRouter(
+  config: LLMConfig,
+  system: string,
+  user: string,
+): Promise<string> {
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: config.model,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: user },
+      ],
+    }),
+  })
+  if (!res.ok) {
+    const err = await res.text().catch(() => res.statusText)
+    throw new Error(`OpenRouter ${res.status}: ${err}`)
+  }
+  const data = (await res.json()) as {
+    choices: Array<{ message: { content: string } }>
+  }
+  return data.choices[0]?.message.content ?? ''
 }

--- a/src/shared/types/llm.ts
+++ b/src/shared/types/llm.ts
@@ -1,4 +1,11 @@
-export type LLMProvider = "anthropic" | "openai" | "google" | "mistral" | "perplexity" | "ollama"
+export type LLMProvider =
+  | 'anthropic'
+  | 'openai'
+  | 'google'
+  | 'mistral'
+  | 'perplexity'
+  | 'ollama'
+  | 'openrouter'
 
 export interface LLMConfig {
   provider: LLMProvider
@@ -8,41 +15,68 @@ export interface LLMConfig {
 }
 
 export const DEFAULT_LLM_CONFIG: LLMConfig = {
-  provider: "anthropic",
-  apiKey: "",
-  model: "claude-sonnet-4-6",
-  ollamaBaseUrl: "http://localhost:11434",
+  provider: 'anthropic',
+  apiKey: '',
+  model: 'claude-sonnet-4-6',
+  ollamaBaseUrl: 'http://localhost:11434',
 }
 
-export const LLM_PROVIDERS: Record<LLMProvider, { label: string; models: string[]; needsKey: boolean }> = {
+export const LLM_PROVIDERS: Record<
+  LLMProvider,
+  { label: string; models: string[]; needsKey: boolean }
+> = {
   anthropic: {
-    label: "Anthropic",
-    models: ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
+    label: 'Anthropic',
+    models: [
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5-20251001',
+    ],
     needsKey: true,
   },
   openai: {
-    label: "OpenAI",
-    models: ["gpt-4o", "gpt-4o-mini", "o1-mini"],
+    label: 'OpenAI',
+    models: ['gpt-4o', 'gpt-4o-mini', 'o1-mini'],
     needsKey: true,
   },
   google: {
-    label: "Google",
-    models: ["gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash"],
+    label: 'Google',
+    models: ['gemini-2.0-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'],
     needsKey: true,
   },
   mistral: {
-    label: "Mistral",
-    models: ["mistral-large-latest", "mistral-small-latest", "open-mistral-nemo"],
+    label: 'Mistral',
+    models: [
+      'mistral-large-latest',
+      'mistral-small-latest',
+      'open-mistral-nemo',
+    ],
     needsKey: true,
   },
   perplexity: {
-    label: "Perplexity",
-    models: ["sonar-pro", "sonar", "sonar-reasoning"],
+    label: 'Perplexity',
+    models: ['sonar-pro', 'sonar', 'sonar-reasoning'],
     needsKey: true,
   },
   ollama: {
-    label: "Ollama (local)",
+    label: 'Ollama (local)',
     models: [],
     needsKey: false,
+  },
+  openrouter: {
+    label: 'OpenRouter',
+    models: [
+      'anthropic/claude-sonnet-4-6',
+      'openai/gpt-4o',
+      'google/gemini-2.0-flash',
+      'mistral/mistral-large-latest',
+      'stepfun/step-3.5-flash:free',
+      'arcee-ai/trinity-large-preview:free',
+      'z-ai/glm-4.5-air:free',
+      'arcee-ai/trinity-mini:free',
+      'google/gemma-3-27b-it:free',
+      'openrouter/free',
+    ],
+    needsKey: true,
   },
 }


### PR DESCRIPTION
## Description

This PR adds **OpenRouter** as an LLM provider in Bonap, allowing users to access multiple models (Claude, GPT-4o, Gemini, Mistral, etc.) through a single OpenRouter API key.

## Changes

### `src/shared/types/llm.ts`

- Added `"openrouter"` to the `LLMProvider` union type
- Added `openrouter` entry in `LLM_PROVIDERS` with:
  - Label: `"OpenRouter"`
  - Pre-configured models: `anthropic/claude-sonnet-4-6`, `openai/gpt-4o`, `google/gemini-2.0-flash`, `mistral/mistral-large-latest`, and several free models
  - `needsKey: true` (requires an API key)

### `src/infrastructure/llm/LLMService.ts`

- Added `callOpenRouter()`: calls `https://openrouter.ai/api/v1/chat/completions` using the OpenAI-compatible format (Bearer auth, system/user messages)
- Added `case "openrouter"` in the `llmChat()` switch statement

### `src/infrastructure/llm/AssistantService.ts`

- Added OpenRouter to the `chatFallback()` condition (used by AssistantDrawer for non-Anthropic providers)
- Added OpenRouter endpoint to the `endpoints` map

### `src/infrastructure/llm/LLMConfigService.ts`

- Added `testOpenRouter()`: sends a test request with `max_tokens: 1` to validate the API key
- Added `case "openrouter"` in the `testConnection()` switch statement

## How to test

1. Go to **Settings** (`/settings`)
2. Select **OpenRouter** as the provider
3. Enter a valid OpenRouter API key
4. Choose a model from the list (e.g., `anthropic/claude-sonnet-4-6`)
5. Click **Test Connection** → should display "Clé valide"
6. Test the AI assistant (Sparkles button) and suggestions

## Notes

- OpenRouter uses the **OpenAI-compatible** format (`/v1/chat/completions`), so the implementation mirrors `callOpenAI` with a different base URL
- The Settings UI is fully data-driven by `LLM_PROVIDERS`: no changes needed in `SettingsPage.tsx`
- The AssistantDrawer fallback (non-streaming, no tools) is used, same as other non-Anthropic providers

<img width="875" height="696" alt="image_2026-04-03_211912500" src="https://github.com/user-attachments/assets/6a02cfb2-e291-4b5d-92d2-489510eaaeb1" />