### PR TITLE
feat: intégrer corrections PR #18 (formatDuration + TypeScript)

### DIFF
--- a/src/application/auth/usecases/LoginUseCase.ts
+++ b/src/application/auth/usecases/LoginUseCase.ts
@@ -1,0 +1,14 @@
+import type { IAuthRepository } from '../../../domain/auth/repositories/IAuthRepository.ts'
+import type { AuthTokens } from '../../../domain/auth/entities/AuthTokens.ts'
+
+export class LoginUseCase {
+  private authRepository: IAuthRepository
+
+  constructor(authRepository: IAuthRepository) {
+    this.authRepository = authRepository
+  }
+
+  async execute(username: string, password: string): Promise<AuthTokens> {
+    return this.authRepository.login(username, password)
+  }
+}

--- a/src/application/auth/usecases/LogoutUseCase.ts
+++ b/src/application/auth/usecases/LogoutUseCase.ts
@@ -1,0 +1,13 @@
+import type { IAuthRepository } from '../../../domain/auth/repositories/IAuthRepository.ts'
+
+export class LogoutUseCase {
+  private authRepository: IAuthRepository
+
+  constructor(authRepository: IAuthRepository) {
+    this.authRepository = authRepository
+  }
+
+  async execute(): Promise<void> {
+    await this.authRepository.logout()
+  }
+}

--- a/src/domain/auth/entities/AuthTokens.ts
+++ b/src/domain/auth/entities/AuthTokens.ts
@@ -1,0 +1,4 @@
+export interface AuthTokens {
+  accessToken: string
+  tokenType: string
+}

--- a/src/domain/auth/repositories/IAuthRepository.ts
+++ b/src/domain/auth/repositories/IAuthRepository.ts
@@ -1,0 +1,6 @@
+import type { AuthTokens } from '../entities/AuthTokens.ts'
+
+export interface IAuthRepository {
+  login(username: string, password: string): Promise<AuthTokens>
+  logout(): Promise<void>
+}

--- a/src/infrastructure/container.ts
+++ b/src/infrastructure/container.ts
@@ -18,6 +18,11 @@ import { CategoryRepository } from "./mealie/repositories/CategoryRepository.ts"
 import { TagRepository } from "./mealie/repositories/TagRepository.ts"
 import { FoodRepository } from "./mealie/repositories/FoodRepository.ts"
 import { UnitRepository } from "./mealie/repositories/UnitRepository.ts"
+import { AuthRepository } from "./mealie/repositories/AuthRepository.ts"
+
+// Use cases — auth
+import { LoginUseCase } from "../application/auth/usecases/LoginUseCase.ts"
+import { LogoutUseCase } from "../application/auth/usecases/LogoutUseCase.ts"
 
 // Use cases — recipe
 import { GetRecipesUseCase } from "../application/recipe/usecases/GetRecipesUseCase.ts"
@@ -69,6 +74,12 @@ export const categoryRepository = new CategoryRepository()
 export const tagRepository = new TagRepository()
 export const foodRepository = new FoodRepository()
 export const unitRepository = new UnitRepository()
+export const authRepository = new AuthRepository()
+
+// --- Singleton use case instances — auth ---
+
+export const loginUseCase = new LoginUseCase(authRepository)
+export const logoutUseCase = new LogoutUseCase(authRepository)
 
 // --- Singleton use case instances — recipe ---
 

--- a/src/infrastructure/mealie/repositories/AuthRepository.ts
+++ b/src/infrastructure/mealie/repositories/AuthRepository.ts
@@ -1,0 +1,64 @@
+import type { IAuthRepository } from '../../../domain/auth/repositories/IAuthRepository.ts'
+import type { AuthTokens } from '../../../domain/auth/entities/AuthTokens.ts'
+import {
+  getEnv,
+  getIngressBasename,
+  isDockerRuntime,
+} from '../../../shared/utils/env.ts'
+import { MealieApiError } from '../../../shared/types/errors.ts'
+
+function getBaseUrl(): string {
+  if (import.meta.env.DEV) return ''
+  if (isDockerRuntime()) return getIngressBasename()
+  return getEnv('VITE_MEALIE_URL').replace(/\/+$/, '')
+}
+
+export class AuthRepository implements IAuthRepository {
+  async login(username: string, password: string): Promise<AuthTokens> {
+    const url = `${getBaseUrl()}/api/auth/token`
+
+    const body = new URLSearchParams()
+    body.append('grant_type', '')
+    body.append('username', username)
+    body.append('password', password)
+    body.append('scope', '')
+    body.append('client_id', '')
+    body.append('client_secret', '')
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    })
+
+    if (!response.ok) {
+      const message = await response.text().catch(() => response.statusText)
+      throw new MealieApiError(
+        response.status === 401 ? 'Identifiants invalides' : message,
+        response.status,
+      )
+    }
+
+    const data = (await response.json()) as {
+      access_token: string
+      token_type: string
+    }
+
+    return {
+      accessToken: data.access_token,
+      tokenType: data.token_type,
+    }
+  }
+
+  async logout(): Promise<void> {
+    const url = `${getBaseUrl()}/api/auth/logout`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    })
+    if (!response.ok) {
+      const message = await response.text().catch(() => response.statusText)
+      throw new MealieApiError(message, response.status)
+    }
+  }
+}

--- a/src/infrastructure/theme/ThemeService.ts
+++ b/src/infrastructure/theme/ThemeService.ts
@@ -48,7 +48,7 @@ export class ThemeService {
   getTheme(): Theme {
     const envTheme = getEnv("VITE_THEME")
 
-    const isTheme = (v: any): v is Theme =>
+    const isTheme = (v: unknown): v is Theme =>
       v === "light" || v === "dark" || v === "system"
     
     // 1. ENV
@@ -60,7 +60,9 @@ export class ThemeService {
     try {
       const stored = localStorage.getItem(THEME_KEY)
       if (isTheme(stored)) return stored
-    } catch (_) { }
+    } catch {
+      // nothing
+    }
 
     // 3. fallback
     return "system"
@@ -69,7 +71,9 @@ export class ThemeService {
   setTheme(theme: Theme): void {
     try {
       localStorage.setItem(THEME_KEY, theme)
-    } catch (_) {}
+    } catch {
+      // nothing
+    }
     this.apply()
   }
 
@@ -80,14 +84,18 @@ export class ThemeService {
         const found = ACCENT_COLORS.find((c) => c.id === stored)
         if (found) return found
       }
-    } catch (_) {}
+    } catch {
+      // nothing
+    }
     return DEFAULT_ACCENT
   }
 
   setAccentColor(color: AccentColor): void {
     try {
       localStorage.setItem(ACCENT_KEY, color.id)
-    } catch (_) {}
+    } catch {
+      // nothing
+    }
     this.apply()
   }
 

--- a/src/presentation/components/AssistantDrawer.tsx
+++ b/src/presentation/components/AssistantDrawer.tsx
@@ -9,8 +9,7 @@ import { llmConfigService } from "../../infrastructure/llm/LLMConfigService.ts"
 
 
 export function AssistantDrawer() {
-
-  if (!llmConfigService.isConfigured()) return null
+  const isConfigured = llmConfigService.isConfigured()
 
   const [open, setOpen] = useState(false)
   const [input, setInput] = useState("")
@@ -31,6 +30,8 @@ export function AssistantDrawer() {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
   }, [messages])
+
+  if (!isConfigured) return null
 
   const handleSend = async () => {
     const text = input.trim()

--- a/src/presentation/components/PlanningSlotPicker.tsx
+++ b/src/presentation/components/PlanningSlotPicker.tsx
@@ -4,20 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog.ts
 import { getPlanningRangeUseCase } from "../../infrastructure/container.ts"
 import type { MealieMealPlan } from "../../shared/types/mealie.ts"
 import { cn } from "../../lib/utils.ts"
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-export function toDateStr(d: Date): string {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, "0")
-  const day = String(d.getDate()).padStart(2, "0")
-  return `${y}-${m}-${day}`
-}
-
-function formatDayFr(dateStr: string): string {
-  const d = new Date(dateStr + "T12:00:00")
-  return d.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" })
-}
+import { toDateStr, formatDayFr } from "../../shared/utils/date.ts"
 
 // ─── PlanningSlotPicker ───────────────────────────────────────────────────────
 

--- a/src/presentation/components/RecipeDrawer.tsx
+++ b/src/presentation/components/RecipeDrawer.tsx
@@ -21,7 +21,7 @@ import { cn } from "../../lib/utils"
 import { RecipeIngredientsList } from "./RecipeIngredientsList"
 import { RecipeInstructionsList } from "./RecipeInstructionsList"
 
-import type { MealieCategory, Season } from "../../shared/types/mealie"
+import type { MealieCategory, MealieRatings, Season } from "../../shared/types/mealie"
 import { SEASONS, SEASON_LABELS } from "../../shared/types/mealie"
 
 import { addMealUseCase, deleteMealUseCase } from "../../infrastructure/container"
@@ -52,7 +52,7 @@ export function RecipeDrawer({ slug, allCategories, closing, onClose }: RecipeDr
     const [planningPickerOpen, setPlanningPickerOpen] = useState(false)
     const syncLock = useRef(false)
     const { getFavorites } = useGetFavorites()
-    const [ratings, setRatings] = useState<any[]>([])
+    const [ratings, setRatings] = useState<MealieRatings[]>([])
 
     useEffect(() => {
         if (!recipe) return
@@ -100,7 +100,7 @@ export function RecipeDrawer({ slug, allCategories, closing, onClose }: RecipeDr
         }
 
         run()
-    }, [recipe?.slug])
+    }, [recipe, updateCalorieTag, setRecipe, getFavorites])
 
     const handleSlotSelect = async (date: string, entryType: string, existingMealId?: number) => {
         if (!recipe) return

--- a/src/presentation/components/RecipeEditorShared.tsx
+++ b/src/presentation/components/RecipeEditorShared.tsx
@@ -8,32 +8,6 @@ import { Input } from "./ui/input.tsx"
 import { formatDuration } from "../../shared/utils/duration.ts"
 import { cn } from "../../lib/utils.ts"
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-export function parsePrepTimeToMinutes(value?: string): string {
-  if (!value) return ""
-  if (/^\d+$/.test(value.trim())) {
-    const n = parseInt(value.trim(), 10)
-    return n > 0 ? String(n) : ""
-  }
-  const match = value.match(/PT(?:(\d+)H)?(?:(\d+)M)?/)
-  if (!match) return ""
-  const hours = parseInt(match[1] ?? "0")
-  const minutes = parseInt(match[2] ?? "0")
-  const total = hours * 60 + minutes
-  return total > 0 ? String(total) : ""
-}
-
-export function formatMinutes(value: string): string {
-  const n = Number(value)
-  if (!n || n <= 0) return ""
-  const h = Math.floor(n / 60)
-  const m = n % 60
-  if (h > 0 && m > 0) return `${h} h ${m} min`
-  if (h > 0) return `${h} h`
-  return `${m} min`
-}
-
 // ─── InlineEditText ───────────────────────────────────────────────────────────
 
 export interface InlineEditTextProps {
@@ -68,16 +42,18 @@ export function InlineEditText({
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    if (editing) {
-      if (multiline && textareaRef.current) {
-        textareaRef.current.focus()
-        const len = textareaRef.current.value.length
-        textareaRef.current.setSelectionRange(len, len)
-      } else if (!multiline && inputRef.current) {
-        inputRef.current.focus()
-        const len = inputRef.current.value.length
-        inputRef.current.setSelectionRange(len, len)
-      }
+    if (!editing) return
+
+    if (multiline && textareaRef.current) {
+      textareaRef.current.focus()
+      const len = textareaRef.current.value.length
+      textareaRef.current.setSelectionRange(len, len)
+    }
+
+    if (!multiline && inputRef.current) {
+      inputRef.current.focus()
+      const len = inputRef.current.value.length
+      inputRef.current.setSelectionRange(len, len)
     }
   }, [editing, multiline])
 
@@ -143,7 +119,13 @@ export interface InlineEditDurationProps {
   disabled?: boolean
 }
 
-export function InlineEditDuration({ label, value, displayRaw, onChange, disabled }: InlineEditDurationProps) {
+export function InlineEditDuration({
+  label,
+  value,
+  displayRaw,
+  onChange,
+  disabled,
+}: InlineEditDurationProps) {
   const [editing, setEditing] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -180,7 +162,7 @@ export function InlineEditDuration({ label, value, displayRaw, onChange, disable
       )}
       title={disabled ? undefined : "Cliquer pour modifier"}
     >
-      {label} : {displayRaw ? formatDuration(displayRaw) : (value ? formatMinutes(value) : "—")}
+      {label} : {formatDuration(displayRaw ?? value)}
     </span>
   )
 }

--- a/src/presentation/hooks/useSidebar.ts
+++ b/src/presentation/hooks/useSidebar.ts
@@ -5,7 +5,7 @@ const STORAGE_KEY = "bonap-sidebar-collapsed"
 function getStoredCollapsed(): boolean {
   try {
     return localStorage.getItem(STORAGE_KEY) === "true"
-  } catch (_) {
+  } catch {
     return false
   }
 }
@@ -21,7 +21,9 @@ export function useSidebar() {
       const next = !prev
       try {
         localStorage.setItem(STORAGE_KEY, String(next))
-      } catch (_) {}
+      } catch {
+        // nothing
+      }
       return next
     })
   }, [])

--- a/src/presentation/pages/RecipeDetailPage.tsx
+++ b/src/presentation/pages/RecipeDetailPage.tsx
@@ -17,8 +17,8 @@ import { Autocomplete } from "../components/ui/autocomplete.tsx"
 import {
   InlineEditText,
   InlineEditDuration,
-  parsePrepTimeToMinutes,
 } from "../components/RecipeEditorShared.tsx"
+import { formatDuration } from "../../shared/utils/duration.ts"
 import {
   Loader2,
   Plus,
@@ -40,6 +40,7 @@ import type {
   RecipeFormData,
   RecipeFormIngredient,
   RecipeFormInstruction,
+  MealieRatings
 } from "../../shared/types/mealie.ts"
 import { SEASONS, SEASON_LABELS } from "../../shared/types/mealie.ts"
 import { getRecipeSeasonsFromTags, isSeasonTag } from "../../shared/utils/season.ts"
@@ -69,9 +70,9 @@ function buildFormData(recipe: MealieRecipe): RecipeFormData {
   return {
     name: recipe.name,
     description: recipe.description ?? "",
-    prepTime: parsePrepTimeToMinutes(recipe.prepTime),
-    performTime: parsePrepTimeToMinutes(recipe.performTime),
-    totalTime: parsePrepTimeToMinutes(recipe.totalTime),
+    prepTime: formatDuration(recipe.prepTime),
+    performTime: formatDuration(recipe.performTime),
+    totalTime: formatDuration(recipe.totalTime),
     recipeIngredient: [
       ...structured,
       { quantity: "1", unit: "", unitId: undefined, food: "", foodId: undefined, note: "" },
@@ -135,26 +136,32 @@ export function RecipeDetailPage() {
   // ─── Local editable state (initialized from recipe) ────────────────────────
 
   const [formData, setFormData] = useState<RecipeFormData | null>(null)
-  const [isDirty, setIsDirty] = useState(false)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
+  const [isDirty, setIsDirty] = useState(false)
   const [cookingMode, setCookingMode] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { getFavorites } = useGetFavorites()
-  const [ratings, setRatings] = useState<any[]>([])
+  const [ratings, setRatings] = useState<MealieRatings[]>([])
 
   // Initialise formData once recipe is loaded
-  useEffect(() => {
-    if (recipe && !formData) {
-      setFormData(buildFormData(recipe))
-      setImagePreview(recipeImageUrl(recipe, "original"))
-    }
+  if (recipe && !formData) {
+    setFormData(buildFormData(recipe))
+    setImagePreview(recipeImageUrl(recipe, "original"))
+  }
 
-    // Get favorites
-    void (async () => {
+  // Take Favorite
+  useEffect(() => {
+    let mounted = true
+    const load = async () => {
       const data = await getFavorites()
+      if (!mounted) return
       setRatings(data.ratings)
-    })()
-  }, [recipe, formData])
+    }
+    void load()
+    return () => {
+      mounted = false
+    }
+  }, [getFavorites])
 
   const patch = useCallback((partial: Partial<RecipeFormData>) => {
     setFormData((prev) => (prev ? { ...prev, ...partial } : prev))

--- a/src/presentation/pages/SettingsPage.tsx
+++ b/src/presentation/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useRef } from "react"
 import { getEnv, getIngressBasename } from "../../shared/utils/env.ts"
 import { Eye, EyeOff, CheckCircle2, XCircle, Loader2, Check, Sun, Moon, Monitor, Palette, Bot, Server, Info, Lock, AlertTriangle } from "lucide-react"
 import { Button } from "../components/ui/button.tsx"
@@ -35,19 +35,24 @@ export function SettingsPage() {
   const [showKey, setShowKey] = useState(false)
   const [testStatus, setTestStatus] = useState<TestStatus>({ state: "idle" })
   const [saved, setSaved] = useState(false)
-
-  useEffect(() => {
-    llmConfigService.save(config)
-    setSaved(true)
-    const t = setTimeout(() => setSaved(false), 1500)
-    return () => clearTimeout(t)
-  }, [config])
+  const timeoutRef = useRef<number | null>(null)
 
   const providerInfo = LLM_PROVIDERS[config.provider]
 
+  const updateConfig = (updater: (prev: LLMConfig) => LLMConfig) => {
+    setConfig((prev) => {
+      const next = updater(prev)
+      llmConfigService.save(next)
+      setSaved(true)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setSaved(false), 1500)
+      return next
+    })
+  }
+
   const handleProviderChange = (provider: LLMProvider) => {
     const info = LLM_PROVIDERS[provider]
-    setConfig((prev) => ({
+    updateConfig((prev) => ({
       ...prev,
       provider,
       model: info.models[0] ?? "",
@@ -221,7 +226,9 @@ export function SettingsPage() {
                 type={showKey ? "text" : "password"}
                 placeholder={envFields.has("apiKey") ? "Définie via variable d'environnement" : `Clé ${providerInfo.label}`}
                 value={config.apiKey}
-                onChange={(e) => setConfig((prev) => ({ ...prev, apiKey: e.target.value }))}
+                onChange={(e) =>
+                  updateConfig((prev) => ({ ...prev, apiKey: e.target.value }))
+                }
                 readOnly={envFields.has("apiKey")}
                 className={cn("pr-10", envFields.has("apiKey") && "bg-secondary/40")}
                 autoComplete="off"
@@ -251,7 +258,9 @@ export function SettingsPage() {
                 type="text"
                 placeholder="http://localhost:11434"
                 value={config.ollamaBaseUrl}
-                onChange={(e) => setConfig((prev) => ({ ...prev, ollamaBaseUrl: e.target.value }))}
+                onChange={(e) =>
+                  updateConfig((prev) => ({ ...prev, ollamaBaseUrl: e.target.value }))
+                }
                 readOnly={envFields.has("ollamaBaseUrl")}
                 className={cn(envFields.has("ollamaBaseUrl") && "bg-secondary/40")}
               />
@@ -263,7 +272,9 @@ export function SettingsPage() {
                 type="text"
                 placeholder="llama3.2, mistral, …"
                 value={config.model}
-                onChange={(e) => setConfig((prev) => ({ ...prev, model: e.target.value }))}
+                onChange={(e) =>
+                  updateConfig((prev) => ({ ...prev, model: e.target.value }))
+                }
               />
             </div>
           </div>
@@ -281,7 +292,9 @@ export function SettingsPage() {
                 <button
                   key={m}
                   type="button"
-                  onClick={() => !envFields.has("model") && setConfig((prev) => ({ ...prev, model: m }))}
+                  onClick={() =>
+                    updateConfig((prev) => ({ ...prev, model: m }))
+                  }
                   disabled={envFields.has("model")}
                   className={cn(
                     "rounded-[var(--radius-lg)] border px-3 py-1.5",

--- a/src/presentation/pages/SettingsPage.tsx
+++ b/src/presentation/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from "react"
+import { useNavigate } from "react-router-dom"
 import { getEnv, getIngressBasename } from "../../shared/utils/env.ts"
-import { Eye, EyeOff, CheckCircle2, XCircle, Loader2, Check, Sun, Moon, Monitor, Palette, Bot, Server, Info, Lock, AlertTriangle } from "lucide-react"
+import { Eye, EyeOff, CheckCircle2, XCircle, Loader2, Check, Sun, Moon, Monitor, Palette, Bot, Server, Info, Lock, AlertTriangle, LogOut } from "lucide-react"
 import { Button } from "../components/ui/button.tsx"
 import { Input } from "../components/ui/input.tsx"
 import { Label } from "../components/ui/label.tsx"
@@ -11,6 +12,7 @@ import { useTheme } from "../hooks/useTheme.ts"
 import { ACCENT_COLORS } from "../../infrastructure/theme/ThemeService.ts"
 import type { Theme } from "../../infrastructure/theme/ThemeService.ts"
 import { cn } from "../../lib/utils.ts"
+import { logoutUseCase } from "../../infrastructure/container.ts"
 
 type TestStatus = { state: "idle" } | { state: "loading" } | { state: "ok"; message: string } | { state: "error"; message: string }
 
@@ -30,6 +32,7 @@ const THEME_OPTIONS: { value: Theme; label: string; icon: typeof Sun }[] = [
 
 export function SettingsPage() {
   const { theme, setTheme, accentColor, setAccentColor } = useTheme()
+  const navigate = useNavigate()
   const [config, setConfig] = useState<LLMConfig>(() => llmConfigService.load())
   const envFields = getLLMEnvFields()
   const [showKey, setShowKey] = useState(false)
@@ -65,6 +68,19 @@ export function SettingsPage() {
     setTestStatus({ state: "loading" })
     const result = await llmConfigService.testConnection(config)
     setTestStatus(result.ok ? { state: "ok", message: result.message } : { state: "error", message: result.message })
+  }
+
+  const handleLogout = async () => {
+    try {
+      await logoutUseCase.execute()
+    } catch {
+      // ignore — always clear local state
+    } finally {
+      localStorage.removeItem('bonap-mealie-url')
+      localStorage.removeItem('bonap-mealie-token')
+      window.__ENV__ = undefined
+      navigate('/login', { replace: true })
+    }
   }
 
   return (
@@ -401,6 +417,26 @@ export function SettingsPage() {
           </div>
         </div>
       </section>
+
+      {/* ── Section Déconnexion ── */}
+      {import.meta.env.VITE_PROTECTED_ROUTE === 'true' && (
+        <section className="rounded-[var(--radius-2xl)] border border-border/50 bg-card shadow-subtle space-y-5 p-6">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-[var(--radius-lg)] bg-destructive/8">
+              <LogOut className="h-4 w-4 text-destructive" />
+            </div>
+            <div>
+              <h2 className="text-base font-bold leading-none">Déconnexion</h2>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Déconnecter le compte actuellement connecté.
+              </p>
+            </div>
+          </div>
+          <Button variant="destructive" onClick={handleLogout}>
+            Se déconnecter
+          </Button>
+        </section>
+      )}
     </div>
   )
 }

--- a/src/presentation/pages/SuggestionsPage.tsx
+++ b/src/presentation/pages/SuggestionsPage.tsx
@@ -3,7 +3,8 @@ import { Sparkles, Loader2, AlertCircle, CalendarPlus, Settings, ChevronRight } 
 import { Link } from "react-router-dom"
 import { Button } from "../components/ui/button.tsx"
 import { Badge } from "../components/ui/badge.tsx"
-import { PlanningSlotPicker, toDateStr } from "../components/PlanningSlotPicker.tsx"
+import { PlanningSlotPicker } from "../components/PlanningSlotPicker.tsx"
+import { toDateStr } from "../../shared/utils/date.ts"
 import { llmChat } from "../../infrastructure/llm/LLMService.ts"
 import { llmConfigService } from "../../infrastructure/llm/LLMConfigService.ts"
 import {

--- a/src/presentation/pages/authPage.tsx
+++ b/src/presentation/pages/authPage.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '../components/ui/button.tsx'
+import { Input } from '../components/ui/input.tsx'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/ui/card.tsx'
+import { Loader2, AlertCircle, UtensilsCrossed } from 'lucide-react'
+import { cn } from '../../lib/utils.ts'
+import { loginUseCase } from '../../infrastructure/container.ts'
+import {
+  getEnv,
+  getIngressBasename,
+  isDockerRuntime,
+} from '../../shared/utils/env.ts'
+
+const STORAGE_KEYS = {
+  MEALIE_URL: 'bonap-mealie-url',
+  MEALIE_TOKEN: 'bonap-mealie-token',
+}
+
+export function AuthPage() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    try {
+      const tokens = await loginUseCase.execute(username, password)
+
+      const mealieUrl = isDockerRuntime()
+        ? getIngressBasename()
+        : getEnv('VITE_MEALIE_URL').replace(/\/+$/, '')
+
+      localStorage.setItem(STORAGE_KEYS.MEALIE_URL, mealieUrl)
+      localStorage.setItem(STORAGE_KEYS.MEALIE_TOKEN, tokens.accessToken)
+
+      window.__ENV__ = {
+        VITE_MEALIE_URL: mealieUrl,
+        VITE_MEALIE_TOKEN: tokens.accessToken,
+      }
+
+      navigate('/recipes', { replace: true })
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Impossible de se connecter',
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-3 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-[var(--radius-xl)] bg-primary/10">
+            <UtensilsCrossed className="h-6 w-6 text-primary" />
+          </div>
+          <div className="space-y-1.5">
+            <CardTitle className="text-2xl">Bienvenue sur Bonap</CardTitle>
+            <CardDescription>
+              Entrez vos identifiants Mealie pour accéder à votre espace
+            </CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="username" className="text-sm font-medium">
+                Nom d'utilisateur
+              </label>
+              <Input
+                id="username"
+                type="text"
+                placeholder="votre@email.com"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+                autoComplete="username"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium">
+                Mot de passe
+              </label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="Votre mot de passe"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error && (
+              <div className="flex items-center gap-2 rounded-[var(--radius-lg)] border border-destructive/20 bg-destructive/8 p-3 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Connexion...
+                </>
+              ) : (
+                'Se connecter'
+              )}
+            </Button>
+          </form>
+
+          <p className={cn('mt-4 text-center text-xs text-muted-foreground')}>
+            Vos identifiants sont échangés directement avec votre instance
+            Mealie
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/shared/types/mealie.ts
+++ b/src/shared/types/mealie.ts
@@ -255,3 +255,8 @@ export interface MealieFavorite {
 export interface MealieFavoritesResponse {
   ratings: MealieFavorite[]
 }
+
+export interface MealieRatings {
+  recipeId: string
+  isFavorite: boolean
+}

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -19,3 +19,15 @@ export function getWeeksBetween(startDate: string, endDate: string): number {
   const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24)) + 1
   return Math.max(1, diffDays / 7)
 }
+
+export function toDateStr(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+export function formatDayFr(dateStr: string): string {
+  const d = new Date(dateStr + "T12:00:00")
+  return d.toLocaleDateString("fr-FR", { weekday: "short", day: "numeric", month: "short" })
+}

--- a/src/shared/utils/duration.ts
+++ b/src/shared/utils/duration.ts
@@ -28,35 +28,44 @@ export function formatDuration(value: string | number | null | undefined): strin
    */
   if (typeof value === "number") {
     totalMinutes = value
-  }
-
-  /**
-   * CASE 2 — string
-   */
-  else if (typeof value === "string") {
-    const v = value.trim().toLowerCase()
+  } else if (typeof value === "string") {
+    let v = value
+      .trim()
+      .toLowerCase()
+      .replace(/\./g, "")        // enlève les points (ex: "min.")
+      .replace(/\u00a0/g, " ")   // espaces insécables
+      .replace(/\s+/g, " ")      // normalise espaces
 
     /**
-     * NEW — format humain : "8 min", "8 minutes"
-     * Permet de supporter des valeurs non ISO venant de l’UI ou API
+     * CASE 1 — "1h10", "1h 10", "1h10m", "2h"
      */
-    const humanMatch = v.match(/^(\d+)\s*(min|mins|minute|minutes)?$/)
-    if (humanMatch) {
-      totalMinutes = parseInt(humanMatch[1], 10)
+    const compactMatch = v.match(/^(\d+)\s*h(?:\s*(\d+)\s*m?)?$/)
+    if (compactMatch) {
+      const hours = parseInt(compactMatch[1], 10)
+      const minutes = parseInt(compactMatch[2] ?? "0", 10)
+      totalMinutes = hours * 60 + minutes
     }
 
     /**
-     * CASE 2.1 — string numérique pur : "90"
+     * CASE 2 — "90", "5 min", "5 minutes"
+     */
+    else if (/^(\d+)\s*(min|mins|minute|minutes)?$/.test(v)) {
+      const match = v.match(/^(\d+)/)
+      totalMinutes = parseInt(match![1], 10)
+    }
+
+    /**
+     * CASE 3 — string numérique "90"
      */
     else if (/^\d+$/.test(v)) {
       totalMinutes = parseInt(v, 10)
     }
 
     /**
-     * CASE 2.2 — ISO 8601 Mealie : "PT1H30M"
+     * CASE 4 — ISO 8601 "PT1H30M"
      */
     else {
-      const match = v.match(/^PT(?:(\d+)H)?(?:(\d+)M)?$/)
+      const match = v.match(/^pt(?:(\d+)h)?(?:(\d+)m)?$/)
 
       if (!match) return "—"
 
@@ -65,23 +74,12 @@ export function formatDuration(value: string | number | null | undefined): strin
 
       totalMinutes = hours * 60 + minutes
     }
-  }
-
-  /**
-   * CASE 3 — type inconnu
-   */
-  else {
+  } else {
     return "—"
   }
 
-  /**
-   * Sécurité : on ignore les valeurs invalides ou nulles
-   */
   if (totalMinutes <= 0) return "—"
 
-  /**
-   * Conversion finale en format lisible
-   */
   const hours = Math.floor(totalMinutes / 60)
   const minutes = totalMinutes % 60
 


### PR DESCRIPTION
## Summary

Intègre proprement les changements de la PR #18 de sargo22341-prog sur une branche sans conflits.

- **`formatDuration` amélioré** : support des formats compacts (`1h10`, `1h 10m`), ISO 8601 case-insensitive, normalisation des espaces insécables
- **`toDateStr`/`formatDayFr`** déplacés dans `shared/utils/date.ts` (évite les exports depuis un composant UI)
- **`MealieRatings`** interface ajoutée dans `mealie.ts`
- **`RecipeEditorShared`** : supprime `parsePrepTimeToMinutes`/`formatMinutes`, `InlineEditDuration` utilise `formatDuration` directement
- **`RecipeDetailPage`** : utilise `formatDuration` pour afficher les temps, corrige le `useEffect` (sépare init formData et chargement favoris avec cleanup `mounted`)
- **`RecipeDrawer`** : remplace `any[]` par `MealieRatings[]`, corrige les deps du `useEffect`
- **`AssistantDrawer`** : corrige une violation des Rules of Hooks (`return null` avant les hooks)
- **`SettingsPage`** : remplace le `useEffect` de sauvegarde par un helper `updateConfig` (sauvegarde immédiate à chaque changement, debounce du badge "Sauvegardé")
- **TypeScript** : nettoyage `catch (_)` → `catch` dans ThemeService et useSidebar

Ferme #18 — les fonctionnalités auth/ratings/favoris de sargo22341-prog sont préservées.

## Test plan
- [ ] `npm run build` passe sans erreurs TypeScript ✅
- [ ] Les durées s'affichent correctement (ISO, minutes, format compact)
- [ ] L'assistant drawer fonctionne si LLM configuré, masqué sinon
- [ ] Les settings sauvegardent immédiatement sans rechargement

🤖 Generated with [Claude Code](https://claude.com/claude-code)