### PR TITLE
fix(shopping): étiquettes — renommer Catégories et respecter l'ordre Mealie

### DIFF
--- a/e2e/shopping.spec.ts
+++ b/e2e/shopping.spec.ts
@@ -162,6 +162,66 @@ test.describe("Liste de courses", () => {
     })
   })
 
+  test.describe("Étiquettes (fixes #20 et #21)", () => {
+    test("affiche 'Étiquettes' et non 'Catégories' dans l'interface", async ({ page }) => {
+      await page.goto("/shopping")
+      await expect(page.getByText("farine")).toBeVisible({ timeout: 8000 })
+
+      // Le bouton de gestion doit afficher Étiquettes
+      await expect(page.getByTitle("Gérer les étiquettes")).toBeVisible()
+      // Aucune occurrence de "Catégories" visible dans la page
+      await expect(page.getByText("Catégories", { exact: true })).not.toBeVisible()
+    })
+
+    test("affiche 'Sans étiquette' pour les articles sans label", async ({ page }) => {
+      // On a besoin de ≥2 groupes pour que les headers soient affichés
+      const itemWithoutLabel = { ...SHOPPING_LIST_BONAP_RESPONSE.listItems[0] }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (itemWithoutLabel as any).label
+
+      await page.route("**/api/households/shopping/lists/list-bonap", async (route) => {
+        await route.fulfill({
+          json: {
+            ...SHOPPING_LIST_BONAP_RESPONSE,
+            listItems: [
+              itemWithoutLabel,
+              SHOPPING_LIST_BONAP_RESPONSE.listItems[1], // mozzarella avec étiquette
+            ],
+          },
+        })
+      })
+
+      await page.goto("/shopping")
+      await expect(page.getByText("farine")).toBeVisible({ timeout: 8000 })
+      await expect(page.getByText("Sans étiquette")).toBeVisible({ timeout: 8000 })
+    })
+
+    test("respecte l'ordre des étiquettes défini dans Mealie", async ({ page }) => {
+      // labelSettings définit l'ordre : Produits laitiers d'abord, Féculents ensuite
+      await page.route("**/api/households/shopping/lists/list-bonap", async (route) => {
+        await route.fulfill({
+          json: {
+            ...SHOPPING_LIST_BONAP_RESPONSE,
+            labelSettings: [
+              { label: { id: "label2", name: "Produits laitiers", color: "#00ff00" } },
+              { label: { id: "label1", name: "Féculents", color: "#ff0000" } },
+            ],
+          },
+        })
+      })
+
+      await page.goto("/shopping")
+      await expect(page.getByText("farine")).toBeVisible({ timeout: 8000 })
+
+      const headers = page.locator(".bg-secondary\\/50 span.uppercase")
+      const texts = await headers.allTextContents()
+      const labelIdx = (name: string) => texts.findIndex((t) => t.toLowerCase().includes(name.toLowerCase()))
+
+      // "Produits laitiers" doit apparaître avant "Féculents"
+      expect(labelIdx("Produits laitiers")).toBeLessThan(labelIdx("Féculents"))
+    })
+  })
+
   test.describe("Vider la liste", () => {
     test("un bouton pour vider les articles cochés est présent", async ({ page }) => {
       await page.route("**/api/households/shopping/lists/list-bonap", async (route) => {

--- a/src/presentation/pages/ShoppingPage.tsx
+++ b/src/presentation/pages/ShoppingPage.tsx
@@ -106,9 +106,9 @@ function LabelDropdown({ labels, value, onChange, className }: LabelDropdownProp
             className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:bg-secondary transition-colors"
           >
             <span className="h-2 w-2 rounded-full bg-border" />
-            Sans catégorie
+            Sans étiquette
           </button>
-          {[...labels].sort((a, b) => a.name.localeCompare(b.name, "fr")).map((l) => (
+          {labels.map((l) => (
             <button
               key={l.id}
               type="button"
@@ -170,7 +170,7 @@ function FormLabelSelect({ labels, value, onChange, disabled }: FormLabelSelectP
             <span className="max-w-[80px] truncate">{selected.name}</span>
           </>
         ) : (
-          <span>Catégorie</span>
+          <span>Étiquette</span>
         )}
         <ChevronDown className="h-3 w-3" />
       </button>
@@ -186,9 +186,9 @@ function FormLabelSelect({ labels, value, onChange, disabled }: FormLabelSelectP
             className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:bg-secondary transition-colors"
           >
             <span className="h-2 w-2 rounded-full bg-border" />
-            Catégorie
+            Étiquette
           </button>
-          {[...labels].sort((a, b) => a.name.localeCompare(b.name, "fr")).map((l) => (
+          {labels.map((l) => (
             <button
               key={l.id}
               type="button"
@@ -491,7 +491,7 @@ interface GroupHeaderProps {
 }
 
 function GroupHeader({ label, isFirst, onAiCategorize, aiCategorizeLoading }: GroupHeaderProps) {
-  const isNone = label === "Sans catégorie"
+  const isNone = label === "Sans étiquette"
   return (
     <div className={cn(
       "flex items-center gap-2 px-4 py-1.5 bg-secondary/50",
@@ -551,7 +551,7 @@ function GroupedItems({ items, labels, onToggle, onDelete, onUpdateQuantity, onU
     const groups = new Map<string, { label: string; color?: string; items: ShoppingItem[] }>()
     for (const item of list) {
       const key = item.label?.id ?? "__none__"
-      const labelName = item.label?.name ?? "Sans catégorie"
+      const labelName = item.label?.name ?? "Sans étiquette"
       if (!groups.has(key)) {
         groups.set(key, { label: labelName, color: item.label?.color, items: [] })
       }
@@ -561,10 +561,13 @@ function GroupedItems({ items, labels, onToggle, onDelete, onUpdateQuantity, onU
     for (const group of groups.values()) {
       group.items.sort((a, b) => itemSortKey(a).localeCompare(itemSortKey(b), "fr"))
     }
-    return [...groups.entries()].sort(([a, ga], [b, gb]) => {
+    const labelOrder = new Map(labels.map((l, i) => [l.id, i]))
+    return [...groups.entries()].sort(([a], [b]) => {
       if (a === "__none__") return 1
       if (b === "__none__") return -1
-      return ga.label.localeCompare(gb.label, "fr")
+      const ia = labelOrder.get(a) ?? Infinity
+      const ib = labelOrder.get(b) ?? Infinity
+      return ia - ib
     })
   }
 
@@ -660,17 +663,20 @@ function GroupedHabituels({ items, cartItems, labels, onAddToCart, onDelete, onU
 
   for (const item of items) {
     const key = item.label?.id ?? "__none__"
-    const labelName = item.label?.name ?? "Sans catégorie"
+    const labelName = item.label?.name ?? "Sans étiquette"
     if (!groups.has(key)) {
       groups.set(key, { label: labelName, color: item.label?.color, items: [] })
     }
     groups.get(key)!.items.push(item)
   }
 
-  const sorted = [...groups.entries()].sort(([a, ga], [b, gb]) => {
+  const labelOrder = new Map(labels.map((l, i) => [l.id, i]))
+  const sorted = [...groups.entries()].sort(([a], [b]) => {
     if (a === "__none__") return 1
     if (b === "__none__") return -1
-    return ga.label.localeCompare(gb.label, "fr")
+    const ia = labelOrder.get(a) ?? Infinity
+    const ib = labelOrder.get(b) ?? Infinity
+    return ia - ib
   })
 
   if (sorted.length === 0) {
@@ -841,10 +847,10 @@ export function ShoppingPage() {
                 "shadow-subtle hover:bg-secondary hover:text-foreground",
                 "transition-all duration-150",
               )}
-              title="Gérer les catégories"
+              title="Gérer les étiquettes"
             >
               <Tag className="h-3.5 w-3.5" />
-              Catégories
+              Étiquettes
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Fixes #20 : renomme "Catégorie(s)" en "Étiquette(s)" dans la liste de courses pour correspondre à la terminologie Mealie
- Fixes #21 : les groupes d'étiquettes respectent maintenant l'ordre défini dans Mealie (ordre du tableau `labelSettings` retourné par l'API) plutôt que l'ordre alphabétique

## Changements

- `ShoppingPage.tsx` : remplacement de tous les textes visibles "Catégorie(s)" → "Étiquette(s)" et "Sans catégorie" → "Sans étiquette"
- Suppression du `.sort()` alphabétique dans les dropdowns et dans `buildGroups` / `GroupedHabituels`
- Tri des groupes par index dans le tableau `labels` (issu de `labelSettings` Mealie)
- 3 nouveaux tests E2E pour couvrir les deux issues

## Test plan

- [ ] La page courses affiche "Étiquettes" dans le bouton de gestion
- [ ] Les articles sans étiquette affichent "Sans étiquette" (visible quand ≥2 groupes)
- [ ] L'ordre des groupes correspond à l'ordre Mealie, vérifié via fixture
- [ ] `npm run lint` et `npm run build` passent
- [ ] `npx playwright test e2e/shopping.spec.ts` : 13/13 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)