### PR TITLE
chore: ajouter la configuration projet .claude

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,13 @@
+# Builder le projet
+
+Lance le build TypeScript + Vite de l'app principale. La sortie est dans `dist/`.
+
+```bash
+npm run build
+```
+
+Pour builder le site de documentation :
+
+```bash
+cd website && npm run build
+```

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -1,0 +1,11 @@
+# Lancer le serveur de développement
+
+Lance le serveur de dev de l'app principale Bonap (React + Vite, port 5173).
+
+```bash
+npm run dev
+```
+
+Proxy actif :
+- `/api` → `VITE_MEALIE_URL` (Mealie)
+- `/anthropic`, `/openai`, `/google-ai` → APIs LLM respectives (contournement CORS)

--- a/.claude/commands/e2e.md
+++ b/.claude/commands/e2e.md
@@ -1,0 +1,21 @@
+# Lancer les tests end-to-end Playwright
+
+Lance les tests e2e Playwright. Requiert que le serveur de dev soit déjà lancé sur le port 5173.
+
+```bash
+npx playwright test
+```
+
+Pour lancer un test spécifique :
+
+```bash
+npx playwright test e2e/<fichier>.spec.ts
+```
+
+Pour voir le rapport HTML après les tests :
+
+```bash
+npx playwright show-report
+```
+
+Les tests sont dans `e2e/`. La config Playwright est dans `playwright.config.ts`.

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,9 @@
+# Lancer le linting
+
+Lance ESLint sur le projet principal.
+
+```bash
+npm run lint
+```
+
+La config ESLint est dans `eslint.config.js`. Le projet utilise ESLint 9 avec les règles TypeScript strict.

--- a/.claude/commands/website.md
+++ b/.claude/commands/website.md
@@ -1,0 +1,9 @@
+# Lancer le serveur de dev du site de documentation
+
+Lance le serveur de dev du site de documentation Bonap (dans `website/`, port 5173).
+
+```bash
+cd website && npm run dev
+```
+
+Le site de doc est indépendant de l'app principale. Il contient les pages d'installation, configuration et fonctionnalités.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(git rebase*)",
+      "Bash(chmod -R 777*)",
+      "Bash(sudo rm*)",
+      "Bash(dd *)",
+      "Bash(mkfs*)"
+    ],
+    "defaultMode": "bypassPermissions"
+  },
+  "language": "Français"
+}


### PR DESCRIPTION
## Summary

Création du répertoire `.claude/` à la racine du projet pour la configuration Claude Code spécifique à Bonap.

**`.claude/settings.json`**
- `bypassPermissions` — mode auto sans prompts
- Liste `deny` pour les commandes destructives (rm -rf, git push --force, git reset --hard, etc.)
- `language: Français`

**`.claude/commands/`** — commandes slash projet :
- `/dev` — lancer le serveur de dev de l'app principale (port 5173)
- `/website` — lancer le serveur de dev du site de documentation
- `/build` — builder l'app ou le site de doc
- `/e2e` — lancer les tests Playwright avec conseils d'usage
- `/lint` — lancer ESLint

## Test plan

- [ ] Vérifier que `/dev` est disponible comme commande slash dans Claude Code
- [ ] Vérifier que les permissions `deny` bloquent bien les commandes dangereuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)