### PR TITLE
chore: ajouter les fichiers standards open source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Signaler un comportement inattendu
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Merci de remplir ce formulaire aussi précisément que possible.
+
+  - type: input
+    id: bonap-version
+    attributes:
+      label: Version de Bonap
+      description: Tag de release ou commit (visible dans les paramètres ou `git log`)
+      placeholder: "ex: v1.0.63"
+    validations:
+      required: true
+
+  - type: input
+    id: mealie-version
+    attributes:
+      label: Version de Mealie
+      placeholder: "ex: v1.12.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Méthode d'installation
+      options:
+        - Docker
+        - Home Assistant addon
+        - Dev local (npm run dev)
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Étapes pour reproduire
+      placeholder: |
+        1. Aller sur...
+        2. Cliquer sur...
+        3. Observer...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportement attendu
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Comportement observé
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / erreurs console (si disponibles)
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion / Question
+    url: https://github.com/AymericLeFeyer/bonap/discussions
+    about: Pour les questions générales, demandez dans les Discussions plutôt que d'ouvrir une issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Proposer une nouvelle fonctionnalité
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Avant de proposer une fonctionnalité, vérifiez qu'elle n'existe pas déjà dans les [issues ouvertes](https://github.com/AymericLeFeyer/bonap/issues) ou les [discussions](https://github.com/AymericLeFeyer/bonap/discussions).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Quel problème cette fonctionnalité résoudrait-elle ?
+      placeholder: "Je me retrouve souvent bloqué quand..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution proposée
+      placeholder: "Il serait utile de pouvoir..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives envisagées
+      description: Avez-vous une solution de contournement actuelle ?
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priorité estimée
+      options:
+        - Nice to have
+        - Utile
+        - Important
+        - Bloquant pour moi

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+
+<!-- Décrivez les changements apportés et pourquoi -->
+
+## Type de changement
+
+- [ ] Bug fix
+- [ ] Nouvelle fonctionnalité
+- [ ] Refactoring (pas de changement de comportement)
+- [ ] Documentation
+- [ ] Maintenance (deps, CI, config...)
+
+## Tests
+
+- [ ] `npm run lint` passe sans erreur
+- [ ] `npm run build` passe sans erreur
+- [ ] Testé manuellement sur une instance Mealie
+- [ ] Tests e2e passent (`npx playwright test`) — si applicable
+
+## Checklist
+
+- [ ] La branche est créée depuis `main` (pas de push direct sur `main`)
+- [ ] Les commits suivent la convention `type(scope): message`
+- [ ] La PR pointe vers `main`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code de conduite — Contributor Covenant
+
+## Notre engagement
+
+Dans l'intérêt de favoriser un environnement ouvert et accueillant, nous nous engageons, en tant que contributeurs et mainteneurs, à faire de la participation à notre projet et à notre communauté une expérience sans harcèlement pour tous, quel que soit l'âge, la taille, le handicap, l'origine ethnique, l'identité et l'expression de genre, le niveau d'expérience, la nationalité, l'apparence, la race, la religion ou l'identité et l'orientation sexuelles.
+
+## Nos standards
+
+Exemples de comportements qui contribuent à créer un environnement positif :
+
+- Utiliser un langage accueillant et inclusif
+- Respecter les différents points de vue et expériences
+- Accepter gracieusement les critiques constructives
+- Se concentrer sur ce qui est le mieux pour la communauté
+- Faire preuve d'empathie envers les autres membres
+
+Exemples de comportements inacceptables :
+
+- L'utilisation de langage ou d'images à caractère sexuel et les avances sexuelles non souhaitées
+- Le trolling, les commentaires insultants ou désobligeants, et les attaques personnelles ou politiques
+- Le harcèlement public ou privé
+- La publication d'informations privées de tiers sans permission explicite
+- Tout autre comportement qui pourrait raisonnablement être considéré comme inapproprié dans un cadre professionnel
+
+## Nos responsabilités
+
+Les mainteneurs du projet sont responsables de la clarification des standards de comportement acceptable et doivent prendre des mesures correctives appropriées et justes en réponse à tout comportement inacceptable.
+
+## Portée
+
+Ce code de conduite s'applique à la fois au sein des espaces du projet et dans les espaces publics lorsqu'un individu représente le projet ou sa communauté.
+
+## Application
+
+Les cas de comportements abusifs, harcelants ou autrement inacceptables peuvent être signalés en contactant l'équipe du projet via les [Issues GitHub](https://github.com/AymericLeFeyer/bonap/issues). Toutes les plaintes seront examinées et traitées de manière confidentielle.
+
+## Attribution
+
+Ce code de conduite est adapté du [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to Bonap
+
+Merci de vouloir contribuer à Bonap ! Ce document explique comment participer au projet.
+
+## Prérequis
+
+- Une instance [Mealie](https://mealie.io) fonctionnelle (v1.x+)
+- Node.js 18+
+- Git
+
+## Mise en place de l'environnement de développement
+
+```bash
+git clone https://github.com/AymericLeFeyer/bonap.git
+cd bonap
+npm install
+cp .env.example .env
+# Remplir VITE_MEALIE_URL et VITE_MEALIE_TOKEN dans .env
+npm run dev
+```
+
+## Workflow de contribution
+
+1. **Fork** le dépôt
+2. **Créer une branche** depuis `main` :
+   - `feat/<sujet>` pour une nouvelle fonctionnalité
+   - `fix/<sujet>` pour un correctif
+   - `chore/<sujet>` pour de la maintenance (deps, config, CI...)
+   - `docs/<sujet>` pour de la documentation
+3. **Développer et tester** localement
+4. **Ouvrir une Pull Request** vers `main` avec une description claire
+
+> Ne jamais pusher directement sur `main`.
+
+## Standards de code
+
+- **TypeScript strict** — pas de `any`, pas de `// @ts-ignore`
+- **Architecture DDD** — respecter la séparation domain / application / infrastructure / presentation (voir `CLAUDE.md` pour le détail)
+- **Pas de store global** — useState + hooks custom uniquement
+- **shadcn/ui + Tailwind** — pas d'autre design system, pas de CSS séparé
+- **Linting** : `npm run lint` doit passer sans erreur avant chaque PR
+
+## Tests
+
+Des tests end-to-end Playwright couvrent les flux critiques (shopping, planning) :
+
+```bash
+# Démarrer le serveur de dev d'abord
+npm run dev
+
+# Puis dans un autre terminal
+npx playwright test
+```
+
+## Proposer une fonctionnalité
+
+Ouvrez d'abord une [Discussion](https://github.com/AymericLeFeyer/bonap/discussions) ou une [Issue](https://github.com/AymericLeFeyer/bonap/issues) avant de commencer à coder, pour valider l'idée avec les mainteneurs.
+
+## Signaler un bug
+
+Utilisez le template d'issue **Bug report**. Incluez :
+- La version de Bonap (tag ou commit)
+- La version de Mealie
+- Les étapes pour reproduire
+- Le comportement attendu vs observé
+
+## Code de conduite
+
+Ce projet suit le [Contributor Covenant](CODE_OF_CONDUCT.md). Soyez respectueux.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Aymeric Le Feyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Versions supportées
+
+| Version | Support |
+|---------|---------|
+| latest  | ✅ |
+| < latest | ❌ |
+
+## Signaler une vulnérabilité
+
+**Ne pas ouvrir une issue publique** pour un problème de sécurité.
+
+Envoyez un e-mail à l'adresse indiquée dans le profil GitHub ou ouvrez un [Security Advisory privé](https://github.com/AymericLeFeyer/bonap/security/advisories/new) sur GitHub.
+
+Incluez :
+- Une description de la vulnérabilité
+- Les étapes pour la reproduire
+- L'impact potentiel
+
+Vous recevrez une réponse sous 48h. Une fois le correctif déployé, la vulnérabilité sera divulguée publiquement via le Security Advisory.
+
+## Notes
+
+Bonap est un front-end qui se connecte à votre instance Mealie via un token API. Il ne stocke aucune donnée sensible côté serveur — le token est dans votre `.env` et les préférences UI en localStorage. Assurez-vous que votre `.env` n'est jamais commité (il est dans `.gitignore`).


### PR DESCRIPTION
## Summary

Ajout des fichiers attendus pour un projet open source communautaire auto-hébergé.

- **`LICENSE`** — MIT (déjà référencé dans le README)
- **`CONTRIBUTING.md`** — setup dev, workflow de contribution (branches obligatoires), standards de code DDD/TS, tests Playwright
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1
- **`SECURITY.md`** — politique de signalement des vulnérabilités (Security Advisory GitHub)
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — formulaire structuré (version Bonap, version Mealie, méthode d'install, étapes, logs)
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — formulaire structuré avec priorité
- **`.github/ISSUE_TEMPLATE/config.yml`** — désactive les issues vides, redirige vers les Discussions
- **`.github/PULL_REQUEST_TEMPLATE.md`** — checklist PR (lint, build, tests, convention de branche)

## Test plan

- [ ] Vérifier que GitHub affiche bien les templates d'issue en créant une nouvelle issue
- [ ] Vérifier que le template PR apparaît à l'ouverture d'une PR
- [ ] Vérifier que la LICENSE est reconnue par GitHub (badge MIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)