### PR TITLE
fix(llm): modèles Gemini 2.5 + fetch dynamique des modèles via API

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -47,7 +47,7 @@ test.describe("Navigation — accès aux pages", () => {
     await expect(page.getByRole("link", { name: /courses/i })).toBeVisible()
     await expect(page.getByRole("link", { name: /recettes/i })).toBeVisible()
     await expect(page.getByRole("link", { name: /statistiques/i })).toBeVisible()
-    await expect(page.getByRole("link", { name: /param/i })).toBeVisible()
+    await expect(page.getByRole("link", { name: "Paramètres", exact: true })).toBeVisible()
   })
 
   test("navigation depuis la sidebar vers Planning", async ({ page }) => {

--- a/src/infrastructure/llm/LLMConfigService.ts
+++ b/src/infrastructure/llm/LLMConfigService.ts
@@ -1,5 +1,5 @@
 import type { LLMConfig, LLMProvider } from '../../shared/types/llm.ts'
-import { DEFAULT_LLM_CONFIG } from '../../shared/types/llm.ts'
+import { DEFAULT_LLM_CONFIG, LLM_PROVIDERS } from '../../shared/types/llm.ts'
 
 const STORAGE_KEY = 'bonap_llm_config'
 
@@ -51,6 +51,29 @@ export class LLMConfigService {
     const config = this.load()
     if (config.provider === 'ollama') return Boolean(config.ollamaBaseUrl)
     return Boolean(config.apiKey)
+  }
+
+  async fetchModels(config: LLMConfig): Promise<string[]> {
+    try {
+      switch (config.provider) {
+        case 'anthropic':
+          return await fetchAnthropicModels(config.apiKey)
+        case 'openai':
+          return await fetchOpenAIModels(config.apiKey)
+        case 'google':
+          return await fetchGoogleModels(config.apiKey)
+        case 'mistral':
+          return await fetchMistralModels(config.apiKey)
+        case 'ollama':
+          return await fetchOllamaModels(config.ollamaBaseUrl)
+        case 'openrouter':
+          return await fetchOpenRouterModels(config.apiKey)
+        default:
+          return LLM_PROVIDERS[config.provider as LLMProvider]?.models ?? []
+      }
+    } catch {
+      return LLM_PROVIDERS[config.provider as LLMProvider]?.models ?? []
+    }
   }
 
   async testConnection(
@@ -173,6 +196,75 @@ async function testOpenRouter(
   if (res.ok || res.status === 400) return { ok: true, message: 'Clé valide' }
   if (res.status === 401) return { ok: false, message: 'Clé invalide (401)' }
   return { ok: false, message: `Erreur ${res.status}` }
+}
+
+async function fetchAnthropicModels(apiKey: string): Promise<string[]> {
+  const res = await fetch('https://api.anthropic.com/v1/models', {
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true',
+    },
+  })
+  if (!res.ok) throw new Error(`${res.status}`)
+  const data = (await res.json()) as { data: { id: string }[] }
+  return data.data.map((m) => m.id).filter((id) => id.startsWith('claude-'))
+}
+
+async function fetchOpenAIModels(apiKey: string): Promise<string[]> {
+  const res = await fetch('https://api.openai.com/v1/models', {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+  if (!res.ok) throw new Error(`${res.status}`)
+  const data = (await res.json()) as { data: { id: string }[] }
+  return data.data
+    .map((m) => m.id)
+    .filter((id) => /^(gpt-|o[1-9]|o[1-9]-|chatgpt-)/.test(id))
+    .sort()
+}
+
+async function fetchGoogleModels(apiKey: string): Promise<string[]> {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
+  )
+  if (!res.ok) throw new Error(`${res.status}`)
+  const data = (await res.json()) as {
+    models: { name: string; supportedGenerationMethods?: string[] }[]
+  }
+  return data.models
+    .filter(
+      (m) =>
+        m.name.includes('/gemini-') &&
+        (m.supportedGenerationMethods ?? []).includes('generateContent'),
+    )
+    .map((m) => m.name.replace('models/', ''))
+    .sort()
+}
+
+async function fetchMistralModels(apiKey: string): Promise<string[]> {
+  const res = await fetch('https://api.mistral.ai/v1/models', {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+  if (!res.ok) throw new Error(`${res.status}`)
+  const data = (await res.json()) as { data: { id: string }[] }
+  return data.data.map((m) => m.id).sort()
+}
+
+async function fetchOllamaModels(baseUrl: string): Promise<string[]> {
+  const url = baseUrl.replace(/\/+$/, '')
+  const res = await fetch(`${url}/api/tags`)
+  if (!res.ok) throw new Error(`${res.status}`)
+  const data = (await res.json()) as { models: { name: string }[] }
+  return data.models.map((m) => m.name)
+}
+
+async function fetchOpenRouterModels(apiKey: string): Promise<string[]> {
+  const res = await fetch('https://openrouter.ai/api/v1/models', {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+  if (!res.ok) throw new Error(`${res.status}`)
+  const data = (await res.json()) as { data: { id: string }[] }
+  return data.data.map((m) => m.id).sort()
 }
 
 export const llmConfigService = new LLMConfigService()

--- a/src/infrastructure/llm/LLMConfigService.ts
+++ b/src/infrastructure/llm/LLMConfigService.ts
@@ -198,6 +198,15 @@ async function testOpenRouter(
   return { ok: false, message: `Erreur ${res.status}` }
 }
 
+// Garde uniquement les alias "latest" Gemini — exclut les versions figées
+// (-001, -002), les dates (-04-17, -12-2025), les previews, exp, tts, image, etc.
+function isGeminiLatestAlias(id: string): boolean {
+  if (/-\d{3}(-|$)/.test(id)) return false          // -001, -002
+  if (/-\d{2}-\d{2,4}(-|$)/.test(id)) return false  // -04-17, -12-2025
+  if (/-(preview|exp|tts|image|live|audio|embedding|robotics|computer-use|deep-research)(-|$)/.test(id)) return false
+  return true
+}
+
 async function fetchAnthropicModels(apiKey: string): Promise<string[]> {
   const res = await fetch('https://api.anthropic.com/v1/models', {
     headers: {
@@ -238,6 +247,7 @@ async function fetchGoogleModels(apiKey: string): Promise<string[]> {
         (m.supportedGenerationMethods ?? []).includes('generateContent'),
     )
     .map((m) => m.name.replace('models/', ''))
+    .filter(isGeminiLatestAlias)
     .sort()
 }
 

--- a/src/presentation/components/AssistantDrawer.tsx
+++ b/src/presentation/components/AssistantDrawer.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react"
-import { Sparkles, X, Send, Trash2, Loader2, Bot, User, Wrench } from "lucide-react"
+import { Sparkles, X, Send, Trash2, Loader2, Bot, User, Wrench, AlertCircle, Settings } from "lucide-react"
+import { Link } from "react-router-dom"
 import ReactMarkdown from "react-markdown"
 import { Button } from "./ui/button.tsx"
 import { Input } from "./ui/input.tsx"
@@ -29,8 +30,6 @@ export function AssistantDrawer() {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
   }, [messages])
-
-  if (!configured) return null
 
   const handleSend = async () => {
     const text = input.trim()
@@ -115,8 +114,45 @@ export function AssistantDrawer() {
           </div>
         </div>
 
+        {/* Not configured warning */}
+        {!configured && (
+          <div className="flex flex-1 flex-col items-center justify-center gap-4 px-5 py-6 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-500/10">
+              <AlertCircle className="h-6 w-6 text-amber-500" />
+            </div>
+            <div className="space-y-1.5">
+              <p className="text-sm font-semibold text-foreground">Assistant non configuré</p>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Configurez un fournisseur IA et une clé API pour utiliser l'assistant.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 w-full">
+              <Link
+                to="/settings"
+                onClick={() => setOpen(false)}
+                className={cn(
+                  "flex items-center justify-center gap-1.5 rounded-[var(--radius-lg)] px-4 py-2",
+                  "bg-primary text-primary-foreground text-sm font-medium",
+                  "hover:bg-primary/90 transition-colors",
+                )}
+              >
+                <Settings className="h-3.5 w-3.5" />
+                Ouvrir les paramètres
+              </Link>
+              <a
+                href="https://bonap.aylabs.fr/docs/configuration/llm"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-muted-foreground underline hover:text-foreground transition-colors"
+              >
+                Aide à la configuration →
+              </a>
+            </div>
+          </div>
+        )}
+
         {/* Messages */}
-        <div className="flex-1 overflow-y-auto scrollbar-thin px-3 py-3 space-y-3">
+        {configured && <div className="flex-1 overflow-y-auto scrollbar-thin px-3 py-3 space-y-3">
           {messages.length === 0 && (
             <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-muted-foreground">
               <Bot className="h-10 w-10 opacity-15" />
@@ -200,10 +236,10 @@ export function AssistantDrawer() {
           )}
 
           <div ref={messagesEndRef} />
-        </div>
+        </div>}
 
         {/* Input */}
-        <div className="border-t border-border/40 px-3 py-3 shrink-0">
+        {configured && <div className="border-t border-border/40 px-3 py-3 shrink-0">
           <div className="flex gap-2">
             <Input
               ref={inputRef}
@@ -224,7 +260,7 @@ export function AssistantDrawer() {
               {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
             </Button>
           </div>
-        </div>
+        </div>}
       </div>
 
       {/* Click-outside overlay */}

--- a/src/presentation/pages/SettingsPage.tsx
+++ b/src/presentation/pages/SettingsPage.tsx
@@ -42,6 +42,10 @@ export function SettingsPage() {
   const [showKey, setShowKey] = useState(false)
   const [testStatus, setTestStatus] = useState<TestStatus>({ state: 'idle' })
   const [saved, setSaved] = useState(false)
+  const [availableModels, setAvailableModels] = useState<string[]>(
+    () => LLM_PROVIDERS[config.provider]?.models ?? [],
+  )
+  const [isFetchingModels, setIsFetchingModels] = useState(false)
 
   useEffect(() => {
     llmConfigService.save(config)
@@ -59,6 +63,7 @@ export function SettingsPage() {
       provider,
       model: info.models[0] ?? '',
     }))
+    setAvailableModels(info.models)
     setTestStatus({ state: 'idle' })
     setShowKey(false)
   }
@@ -71,6 +76,21 @@ export function SettingsPage() {
         ? { state: 'ok', message: result.message }
         : { state: 'error', message: result.message },
     )
+    if (result.ok) {
+      setIsFetchingModels(true)
+      try {
+        const models = await llmConfigService.fetchModels(config)
+        if (models.length > 0) {
+          setAvailableModels(models)
+          setConfig((prev) => ({
+            ...prev,
+            model: models.includes(prev.model) ? prev.model : models[0],
+          }))
+        }
+      } finally {
+        setIsFetchingModels(false)
+      }
+    }
   }
 
   const handleLogout = async () => {
@@ -334,14 +354,17 @@ export function SettingsPage() {
         )}
 
         {/* Sélecteur de modèle */}
-        {config.provider !== 'ollama' && providerInfo.models.length > 0 && (
+        {config.provider !== 'ollama' && availableModels.length > 0 && (
           <div className="space-y-2.5">
             <div className="flex items-center gap-2">
               <Label>Modèle</Label>
               {envFields.has('model') && <EnvBadge />}
+              {isFetchingModels && (
+                <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+              )}
             </div>
             <div className="flex flex-wrap gap-2">
-              {providerInfo.models.map((m) => (
+              {availableModels.map((m) => (
                 <button
                   key={m}
                   type="button"
@@ -394,6 +417,15 @@ export function SettingsPage() {
             <span className="flex items-center gap-1.5 text-sm font-medium text-destructive">
               <XCircle className="h-4 w-4" />
               {testStatus.message}
+              {' — '}
+              <a
+                href="https://bonap.aylabs.fr/docs/configuration/llm"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:no-underline"
+              >
+                Aide à la configuration
+              </a>
             </span>
           )}
           {saved && testStatus.state === 'idle' && (

--- a/src/presentation/pages/SuggestionsPage.tsx
+++ b/src/presentation/pages/SuggestionsPage.tsx
@@ -191,14 +191,24 @@ export function SuggestionsPage() {
           <div className="flex-1 text-sm text-[oklch(0.38_0.10_55)] dark:text-[oklch(0.80_0.08_72)]">
             <strong>Aucun fournisseur IA configuré.</strong> Configurez une clé API pour utiliser cette fonctionnalité.
           </div>
-          <Link
-            to="/settings"
-            className="flex items-center gap-1 text-sm font-semibold text-[oklch(0.42_0.12_55)] hover:text-[oklch(0.28_0.12_50)] dark:text-[oklch(0.72_0.12_72)] transition-colors"
-          >
-            <Settings className="h-3.5 w-3.5" />
-            Paramètres
-            <ChevronRight className="h-3.5 w-3.5" />
-          </Link>
+          <div className="flex items-center gap-3 shrink-0">
+            <Link
+              to="/settings"
+              className="flex items-center gap-1 text-sm font-semibold text-[oklch(0.42_0.12_55)] hover:text-[oklch(0.28_0.12_50)] dark:text-[oklch(0.72_0.12_72)] transition-colors"
+            >
+              <Settings className="h-3.5 w-3.5" />
+              Paramètres
+              <ChevronRight className="h-3.5 w-3.5" />
+            </Link>
+            <a
+              href="https://bonap.aylabs.fr/docs/configuration/llm"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-[oklch(0.52_0.10_55)] dark:text-[oklch(0.65_0.08_72)] underline hover:no-underline transition-colors"
+            >
+              Aide →
+            </a>
+          </div>
         </div>
       )}
 

--- a/src/shared/types/llm.ts
+++ b/src/shared/types/llm.ts
@@ -41,7 +41,7 @@ export const LLM_PROVIDERS: Record<
   },
   google: {
     label: 'Google',
-    models: ['gemini-2.0-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'],
+    models: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'],
     needsKey: true,
   },
   mistral: {
@@ -68,7 +68,7 @@ export const LLM_PROVIDERS: Record<
     models: [
       'anthropic/claude-sonnet-4-6',
       'openai/gpt-4o',
-      'google/gemini-2.0-flash',
+      'google/gemini-2.5-flash',
       'mistral/mistral-large-latest',
       'stepfun/step-3.5-flash:free',
       'arcee-ai/trinity-large-preview:free',


### PR DESCRIPTION
## Summary

- Remplace les modèles Gemini dépréciés (`gemini-1.5-pro`, `gemini-1.5-flash`, `gemini-2.0-flash`) par les modèles GA stables : `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`
- Idem pour OpenRouter : `google/gemini-2.0-flash` → `google/gemini-2.5-flash`
- Ajoute `LLMConfigService.fetchModels()` : après un test de connexion réussi, la liste des modèles est remplacée par ceux retournés par l'API du provider (Anthropic `/v1/models`, OpenAI `/v1/models`, Google `/v1beta/models`, Mistral `/v1/models`, Ollama `/api/tags`, OpenRouter `/api/v1/models`)
- Spinner dans le sélecteur pendant le fetch
- En cas d'erreur de connexion : lien vers `https://bonap.aylabs.fr/docs/configuration/llm`

## Test plan

- [ ] Saisir une clé Anthropic valide → cliquer "Tester" → les modèles claude-* disponibles remplacent la liste statique
- [ ] Saisir une clé Google valide → les modèles gemini-* avec generateContent s'affichent
- [ ] Saisir une clé invalide → message d'erreur + lien "Aide à la configuration"
- [ ] Changer de provider → la liste revient aux modèles par défaut

🤖 Generated with [Claude Code](https://claude.com/claude-code)