### PR TITLE
feat(planning): add per-meal note

### DIFF
--- a/src/domain/planning/repositories/IPlanningRepository.ts
+++ b/src/domain/planning/repositories/IPlanningRepository.ts
@@ -11,4 +11,5 @@ export interface IPlanningRepository {
     recipeId: string
   }): Promise<MealieMealPlan>
   deleteMeal(id: number): Promise<void>
+  updateMealNote(meal: import("../../../shared/types/mealie.ts").MealieMealPlan, text: string): Promise<import("../../../shared/types/mealie.ts").MealieMealPlan>
 }

--- a/src/infrastructure/mealie/repositories/PlanningRepository.ts
+++ b/src/infrastructure/mealie/repositories/PlanningRepository.ts
@@ -30,4 +30,17 @@ export class PlanningRepository implements IPlanningRepository {
   async deleteMeal(id: number): Promise<void> {
     await mealieApiClient.delete(`/api/households/mealplans/${id}`)
   }
+
+  async updateMealNote(meal: MealieMealPlan, text: string): Promise<MealieMealPlan> {
+    return mealieApiClient.put<MealieMealPlan>(`/api/households/mealplans/${meal.id}`, {
+      id: meal.id,
+      date: meal.date,
+      entryType: meal.entryType,
+      title: meal.title ?? "",
+      text,
+      recipeId: meal.recipeId,
+      groupId: meal.groupId,
+      userId: meal.userId,
+    })
+  }
 }

--- a/src/presentation/hooks/usePlanning.ts
+++ b/src/presentation/hooks/usePlanning.ts
@@ -4,6 +4,7 @@ import {
   getWeekPlanningUseCase,
   addMealUseCase,
   deleteMealUseCase,
+  planningRepository,
 } from "../../infrastructure/container.ts"
 import { formatDate } from "../../shared/utils/date.ts"
 
@@ -119,6 +120,19 @@ export function usePlanning() {
     await deleteMealUseCase.execute(id)
   }, [])
 
+  const updateMealNote = useCallback(async (id: number, text: string) => {
+    const meal = mealPlans.find((m) => m.id === id)
+    if (!meal) return
+    // Optimistic update
+    setMealPlans((prev) => prev.map((m) => m.id === id ? { ...m, text } : m))
+    try {
+      await planningRepository.updateMealNote(meal, text)
+    } catch {
+      // Rollback
+      setMealPlans((prev) => prev.map((m) => m.id === id ? { ...m, text: meal.text } : m))
+    }
+  }, [mealPlans])
+
   return {
     mealPlans,
     loading,
@@ -134,5 +148,6 @@ export function usePlanning() {
     goToTodayMobile,
     addMeal,
     deleteMeal,
+    updateMealNote,
   }
 }

--- a/src/presentation/hooks/usePlanning.ts
+++ b/src/presentation/hooks/usePlanning.ts
@@ -113,6 +113,7 @@ export function usePlanning() {
   const addMeal = useCallback(async (date: string, entryType: string, recipeId: string) => {
     const newMeal = await addMealUseCase.execute(date, entryType, recipeId)
     setMealPlans((prev) => [...prev, newMeal])
+    return newMeal
   }, [])
 
   const deleteMeal = useCallback(async (id: number) => {

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -470,8 +470,11 @@ export function PlanningPage() {
     if (draggedMeal.date === targetDate && draggedMeal.entryType === targetType) return
     if (!draggedMeal.recipe) return
     await deleteMeal(draggedMeal.id)
-    await addMeal(targetDate, targetType, draggedMeal.recipe.id)
-  }, [deleteMeal, addMeal])
+    const newMeal = await addMeal(targetDate, targetType, draggedMeal.recipe.id)
+    if (draggedMeal.text && newMeal) {
+      await updateMealNote(newMeal.id, draggedMeal.text)
+    }
+  }, [deleteMeal, addMeal, updateMealNote])
 
   // Use a ref so touch handlers always call the latest version without re-mounting the effect
   const handleDropRef = useRef(handleDrop)

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -3,12 +3,14 @@ import { createPortal } from "react-dom"
 import {
   ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight,
   Plus, Loader2, AlertCircle, Copy, Eye, Trash2, ShoppingCart, CheckCircle2,
+  MessageSquarePlus, MessageSquare,
 } from "lucide-react"
 import { Button } from "../components/ui/button.tsx"
 import { usePlanning } from "../hooks/usePlanning.ts"
 import { useAddRecipesToCart } from "../hooks/useAddRecipesToCart.ts"
 import { RecipePickerDialog } from "../components/RecipePickerDialog.tsx"
 import { RecipeDetailModal } from "../components/RecipeDetailModal.tsx"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../components/ui/dialog.tsx"
 import type { MealieMealPlan, MealieRecipe } from "../../shared/types/mealie.ts"
 import { formatDate } from "../../shared/utils/date.ts"
 import { cn } from "../../lib/utils.ts"
@@ -113,6 +115,7 @@ interface MealCellProps {
   onAdd: () => void
   onDelete: (id: number) => void
   onSelectLeftover: (meal: MealieMealPlan) => void
+  onNote: (meal: MealieMealPlan) => void
   colorClass: string
   date: string
   entryType: string
@@ -121,7 +124,7 @@ interface MealCellProps {
 }
 
 function MealCell({
-  meals, lastMeals, onAdd, onDelete, onSelectLeftover,
+  meals, lastMeals, onAdd, onDelete, onSelectLeftover, onNote,
   colorClass, date, entryType, onDrop, onView,
 }: MealCellProps) {
   const [isDragOver, setIsDragOver] = useState(false)
@@ -221,6 +224,13 @@ function MealCell({
                 </span>
               </div>
 
+              {meal.text && (
+                <div className="px-2 pb-1.5">
+                  <p className="text-[11px] text-muted-foreground italic leading-snug line-clamp-2">
+                    {meal.text}
+                  </p>
+                </div>
+              )}
               <div className="flex border-t border-border/30">
                 {meal.recipe?.slug && (
                   <button
@@ -232,6 +242,22 @@ function MealCell({
                     <Eye className="h-3.5 w-3.5" />
                   </button>
                 )}
+                <button
+                  type="button"
+                  onClick={() => onNote(meal)}
+                  title={meal.text ? "Modifier la note" : "Ajouter une note"}
+                  className={cn(
+                    "flex flex-1 items-center justify-center py-1.5 transition-colors border-l border-border/30",
+                    meal.text
+                      ? "text-primary/70 hover:bg-primary/8 hover:text-primary"
+                      : "text-muted-foreground hover:bg-secondary hover:text-foreground",
+                  )}
+                >
+                  {meal.text
+                    ? <MessageSquare className="h-3.5 w-3.5" />
+                    : <MessageSquarePlus className="h-3.5 w-3.5" />
+                  }
+                </button>
                 <button
                   type="button"
                   onClick={() => onDelete(meal.id)}
@@ -334,7 +360,7 @@ export function PlanningPage() {
   const {
     mealPlans, loading, error, centerDate, nbDays, setNbDays,
     goToPrevDay, goToNextDay, goToPrevPeriod, goToNextPeriod, goToToday, goToTodayMobile,
-    addMeal, deleteMeal,
+    addMeal, deleteMeal, updateMealNote,
   } = usePlanning()
 
   const {
@@ -348,6 +374,7 @@ export function PlanningPage() {
   const [pendingSlot, setPendingSlot] = useState<{ date: string; entryType: string } | null>(null)
   const [previewSlug, setPreviewSlug] = useState<string | null>(null)
   const [mobileMenuMeal, setMobileMenuMeal] = useState<{ meal: MealieMealPlan; y: number } | null>(null)
+  const [noteDialog, setNoteDialog] = useState<{ meal: MealieMealPlan; value: string } | null>(null)
   const mobileMenuMealRef = useRef<((data: { meal: MealieMealPlan; y: number } | null) => void) | null>(null)
 
   // ── Mobile touch drag state ──
@@ -418,6 +445,16 @@ export function PlanningPage() {
     if (!pendingSlot) return
     await addMeal(pendingSlot.date, pendingSlot.entryType, recipe.id)
     setPendingSlot(null)
+  }
+
+  const handleOpenNote = (meal: MealieMealPlan) => {
+    setNoteDialog({ meal, value: meal.text ?? "" })
+  }
+
+  const handleSaveNote = async () => {
+    if (!noteDialog) return
+    await updateMealNote(noteDialog.meal.id, noteDialog.value)
+    setNoteDialog(null)
   }
 
   const handleLeftoverSelect = async (date: Date, entryType: string, meal: MealieMealPlan) => {
@@ -736,6 +773,7 @@ export function PlanningPage() {
                           onAdd={() => handleAddMeal(dateStr, key)}
                           onDelete={deleteMeal}
                           onSelectLeftover={(meal) => void handleLeftoverSelect(date, key, meal)}
+                          onNote={handleOpenNote}
                           colorClass={cn(color, "border-b border-r", borderColor)}
                           date={dateStr}
                           entryType={key}
@@ -821,6 +859,17 @@ export function PlanningPage() {
                 )}
                 <button
                   type="button"
+                  onClick={() => { handleOpenNote(mobileMenuMeal.meal); setMobileMenuMeal(null) }}
+                  className="flex items-center gap-3 px-4 py-3.5 text-sm hover:bg-secondary transition-colors"
+                >
+                  {mobileMenuMeal.meal.text
+                    ? <MessageSquare className="h-4 w-4 text-primary/70" />
+                    : <MessageSquarePlus className="h-4 w-4 text-muted-foreground" />
+                  }
+                  {mobileMenuMeal.meal.text ? "Modifier la note" : "Ajouter une note"}
+                </button>
+                <button
+                  type="button"
                   onClick={() => { void deleteMeal(mobileMenuMeal.meal.id); setMobileMenuMeal(null) }}
                   className="flex items-center gap-3 px-4 py-3.5 text-sm text-destructive hover:bg-destructive/10 transition-colors"
                 >
@@ -839,6 +888,40 @@ export function PlanningPage() {
           </div>
         )
       })()}
+
+      {/* ── Dialog note ── */}
+      <Dialog open={noteDialog !== null} onOpenChange={(v) => { if (!v) setNoteDialog(null) }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="font-heading text-base">Note pour ce repas</DialogTitle>
+            <p className="text-sm text-muted-foreground">
+              {noteDialog?.meal.recipe?.name ?? noteDialog?.meal.title ?? "Repas"}
+            </p>
+          </DialogHeader>
+          <textarea
+            autoFocus
+            rows={3}
+            placeholder="Ex : prévoir une portion sans viande…"
+            value={noteDialog?.value ?? ""}
+            onChange={(e) => setNoteDialog((prev) => prev ? { ...prev, value: e.target.value } : null)}
+            onKeyDown={(e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) void handleSaveNote() }}
+            className={cn(
+              "flex w-full rounded-[var(--radius-lg)] border border-input bg-card",
+              "px-3.5 py-2.5 text-sm placeholder:text-muted-foreground/60",
+              "focus-visible:outline-none focus-visible:border-primary/60 focus-visible:ring-2 focus-visible:ring-ring/30",
+              "resize-none transition-[border-color,box-shadow] duration-150",
+            )}
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setNoteDialog(null)}>
+              Annuler
+            </Button>
+            <Button size="sm" onClick={() => void handleSaveNote()}>
+              Enregistrer
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <RecipePickerDialog
         open={pickerOpen}

--- a/src/shared/types/mealie.ts
+++ b/src/shared/types/mealie.ts
@@ -154,8 +154,12 @@ export interface MealieMealPlan {
   date: string
   entryType: string
   title?: string
+  text?: string
   recipeId?: string
   recipe?: MealieRecipe
+  groupId?: string
+  userId?: string
+  householdId?: string
 }
 
 export interface MealieRawPaginatedMealPlans {


### PR DESCRIPTION
## Summary

- Mealie a un champ `text` sur les meal plans (distinct de `title`), exposé via `PUT /api/households/mealplans/:id` — confirmé par test direct sur l'API
- Ajoute un bouton note (icône `MessageSquarePlus` / `MessageSquare`) dans chaque cellule de repas (desktop) et dans le menu contextuel (mobile)
- La note s'affiche en italique sous le nom de la recette si elle est renseignée
- Optimistic update + rollback en cas d'erreur

Closes #11

## Test plan

- [ ] Desktop : survoler un repas planifié → bouton note visible dans la barre d'actions
- [ ] Cliquer → dialog s'ouvre avec le nom du repas, textarea vide
- [ ] Saisir une note (ex: "prévoir une portion sans viande") → Enregistrer
- [ ] La note apparaît en italique sous le nom de la recette, icône devient `MessageSquare` (plein)
- [ ] Recliquer → la note existante est pré-remplie dans le textarea, modifiable
- [ ] Effacer la note → icône repasse à `MessageSquarePlus`
- [ ] Mobile : tap long sur un repas → menu contextuel avec "Ajouter/Modifier la note"
- [ ] Raccourci Cmd/Ctrl+Enter pour valider depuis le textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)