### PR TITLE
fix: bulk issues #36 #37 #40 #41

### DIFF
--- a/e2e/fixtures/mealie.ts
+++ b/e2e/fixtures/mealie.ts
@@ -1,5 +1,16 @@
 // Fixtures de données Mealie réalistes pour les tests E2E
 
+/** Retourne la date ISO (YYYY-MM-DD) du lundi de la semaine courante + offset en jours. */
+function currentWeekDate(offsetFromMonday: number): string {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const dow = today.getDay() // 0=dim, 1=lun, ..., 6=sam
+  const diffToMonday = dow === 0 ? -6 : 1 - dow
+  const d = new Date(today)
+  d.setDate(today.getDate() + diffToMonday + offsetFromMonday)
+  return d.toISOString().split("T")[0]
+}
+
 export const RECIPE_PIZZA = {
   id: "abc123",
   slug: "pizza-maison",
@@ -99,11 +110,12 @@ export const RECIPES_LIST_RESPONSE = {
 }
 
 // Réponse pour GET /api/households/mealplans
+// Les dates sont dynamiques (lun/mar de la semaine courante) pour rester dans la fenêtre visible.
 export const MEALPLANS_RESPONSE = {
   items: [
     {
       id: 1,
-      date: "2026-04-07",
+      date: currentWeekDate(0), // lundi
       entryType: "dinner",
       title: null,
       recipeId: "abc123",
@@ -116,7 +128,7 @@ export const MEALPLANS_RESPONSE = {
     },
     {
       id: 2,
-      date: "2026-04-08",
+      date: currentWeekDate(1), // mardi
       entryType: "lunch",
       title: null,
       recipeId: "def456",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bonap",
   "private": true,
-  "version": "1.0.68",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/infrastructure/planning/PlanningPreferencesService.ts
+++ b/src/infrastructure/planning/PlanningPreferencesService.ts
@@ -1,0 +1,22 @@
+const KEY = "bonap_planning_prefs"
+
+interface PlanningPrefs {
+  showBreakfast: boolean
+}
+
+const DEFAULT: PlanningPrefs = { showBreakfast: false }
+
+export const planningPrefsService = {
+  load(): PlanningPrefs {
+    try {
+      const raw = localStorage.getItem(KEY)
+      if (!raw) return DEFAULT
+      return { ...DEFAULT, ...JSON.parse(raw) as Partial<PlanningPrefs> }
+    } catch {
+      return DEFAULT
+    }
+  },
+  save(prefs: PlanningPrefs): void {
+    localStorage.setItem(KEY, JSON.stringify(prefs))
+  },
+}

--- a/src/presentation/components/CookingMode.tsx
+++ b/src/presentation/components/CookingMode.tsx
@@ -3,6 +3,7 @@ import { X, ChevronLeft, ChevronRight } from "lucide-react"
 import { Button } from "./ui/button.tsx"
 import { cn } from "../../lib/utils.ts"
 import type { MealieIngredient, MealieInstruction } from "../../shared/types/mealie.ts"
+import { MarkdownContent } from "./MarkdownContent.tsx"
 
 interface CookingModeProps {
   recipeName: string
@@ -171,7 +172,9 @@ function InstructionScreen({
       {instruction.title && (
         <h3 className="font-heading text-2xl font-semibold">{instruction.title}</h3>
       )}
-      <p className="text-2xl leading-relaxed text-foreground">{instruction.text}</p>
+      <MarkdownContent className="text-2xl leading-relaxed text-foreground [&_p]:leading-relaxed [&_ul]:ml-6 [&_ol]:ml-6">
+        {instruction.text ?? ""}
+      </MarkdownContent>
     </div>
   )
 }

--- a/src/presentation/components/MarkdownContent.tsx
+++ b/src/presentation/components/MarkdownContent.tsx
@@ -12,40 +12,41 @@ interface MarkdownContentProps {
  */
 export function MarkdownContent({ children, className }: MarkdownContentProps) {
   return (
-    <ReactMarkdown
-      components={{
-        p: ({ children }) => (
-          <p className="leading-relaxed [&:not(:last-child)]:mb-2">{children}</p>
-        ),
-        strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
-        em: ({ children }) => <em className="italic">{children}</em>,
-        ul: ({ children }) => <ul className="my-2 ml-4 list-disc space-y-1">{children}</ul>,
-        ol: ({ children }) => <ol className="my-2 ml-4 list-decimal space-y-1">{children}</ol>,
-        li: ({ children }) => <li className="leading-relaxed">{children}</li>,
-        h1: ({ children }) => <h1 className="font-heading text-xl font-bold mb-2 mt-3">{children}</h1>,
-        h2: ({ children }) => <h2 className="font-heading text-lg font-bold mb-1.5 mt-3">{children}</h2>,
-        h3: ({ children }) => <h3 className="font-heading text-base font-semibold mb-1 mt-2">{children}</h3>,
-        a: ({ href, children }) => (
-          <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline hover:no-underline">
-            {children}
-          </a>
-        ),
-        code: ({ children }) => (
-          <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">{children}</code>
-        ),
-        pre: ({ children }) => (
-          <pre className="my-2 overflow-x-auto rounded-[var(--radius-lg)] bg-muted p-3 text-sm">{children}</pre>
-        ),
-        hr: () => <hr className="my-3 border-border/40" />,
-        blockquote: ({ children }) => (
-          <blockquote className="my-2 border-l-2 border-primary/40 pl-3 text-muted-foreground italic">
-            {children}
-          </blockquote>
-        ),
-      }}
-      className={cn("text-sm text-muted-foreground", className)}
-    >
-      {children}
-    </ReactMarkdown>
+    <div className={cn("text-sm text-muted-foreground", className)}>
+      <ReactMarkdown
+        components={{
+          p: ({ children }) => (
+            <p className="leading-relaxed [&:not(:last-child)]:mb-2">{children}</p>
+          ),
+          strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
+          em: ({ children }) => <em className="italic">{children}</em>,
+          ul: ({ children }) => <ul className="my-2 ml-4 list-disc space-y-1">{children}</ul>,
+          ol: ({ children }) => <ol className="my-2 ml-4 list-decimal space-y-1">{children}</ol>,
+          li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+          h1: ({ children }) => <h1 className="font-heading text-xl font-bold mb-2 mt-3">{children}</h1>,
+          h2: ({ children }) => <h2 className="font-heading text-lg font-bold mb-1.5 mt-3">{children}</h2>,
+          h3: ({ children }) => <h3 className="font-heading text-base font-semibold mb-1 mt-2">{children}</h3>,
+          a: ({ href, children }) => (
+            <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline hover:no-underline">
+              {children}
+            </a>
+          ),
+          code: ({ children }) => (
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">{children}</code>
+          ),
+          pre: ({ children }) => (
+            <pre className="my-2 overflow-x-auto rounded-[var(--radius-lg)] bg-muted p-3 text-sm">{children}</pre>
+          ),
+          hr: () => <hr className="my-3 border-border/40" />,
+          blockquote: ({ children }) => (
+            <blockquote className="my-2 border-l-2 border-primary/40 pl-3 text-muted-foreground italic">
+              {children}
+            </blockquote>
+          ),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
   )
 }

--- a/src/presentation/components/MarkdownContent.tsx
+++ b/src/presentation/components/MarkdownContent.tsx
@@ -1,0 +1,51 @@
+import ReactMarkdown from "react-markdown"
+import { cn } from "../../lib/utils.ts"
+
+interface MarkdownContentProps {
+  children: string
+  className?: string
+}
+
+/**
+ * Rendu Markdown avec styles cohérents avec le design system Bonap.
+ * Utilisé pour la description et les instructions des recettes.
+ */
+export function MarkdownContent({ children, className }: MarkdownContentProps) {
+  return (
+    <ReactMarkdown
+      components={{
+        p: ({ children }) => (
+          <p className="leading-relaxed [&:not(:last-child)]:mb-2">{children}</p>
+        ),
+        strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
+        em: ({ children }) => <em className="italic">{children}</em>,
+        ul: ({ children }) => <ul className="my-2 ml-4 list-disc space-y-1">{children}</ul>,
+        ol: ({ children }) => <ol className="my-2 ml-4 list-decimal space-y-1">{children}</ol>,
+        li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+        h1: ({ children }) => <h1 className="font-heading text-xl font-bold mb-2 mt-3">{children}</h1>,
+        h2: ({ children }) => <h2 className="font-heading text-lg font-bold mb-1.5 mt-3">{children}</h2>,
+        h3: ({ children }) => <h3 className="font-heading text-base font-semibold mb-1 mt-2">{children}</h3>,
+        a: ({ href, children }) => (
+          <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline hover:no-underline">
+            {children}
+          </a>
+        ),
+        code: ({ children }) => (
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]">{children}</code>
+        ),
+        pre: ({ children }) => (
+          <pre className="my-2 overflow-x-auto rounded-[var(--radius-lg)] bg-muted p-3 text-sm">{children}</pre>
+        ),
+        hr: () => <hr className="my-3 border-border/40" />,
+        blockquote: ({ children }) => (
+          <blockquote className="my-2 border-l-2 border-primary/40 pl-3 text-muted-foreground italic">
+            {children}
+          </blockquote>
+        ),
+      }}
+      className={cn("text-sm text-muted-foreground", className)}
+    >
+      {children}
+    </ReactMarkdown>
+  )
+}

--- a/src/presentation/components/RecipeInstructionsList.tsx
+++ b/src/presentation/components/RecipeInstructionsList.tsx
@@ -1,4 +1,5 @@
 import type { MealieInstruction } from "../../shared/types/mealie.ts"
+import { MarkdownContent } from "./MarkdownContent.tsx"
 
 interface RecipeInstructionsListProps {
   instructions: MealieInstruction[]
@@ -26,7 +27,7 @@ export function RecipeInstructionsList({
               {step.title && (
                 <p className="text-sm font-semibold">{step.title}</p>
               )}
-              <p className="text-sm text-muted-foreground leading-relaxed">{step.text}</p>
+              <MarkdownContent>{step.text ?? ""}</MarkdownContent>
             </div>
           </li>
         ))}

--- a/src/presentation/hooks/usePlanningPreferences.ts
+++ b/src/presentation/hooks/usePlanningPreferences.ts
@@ -1,0 +1,14 @@
+import { useState, useCallback } from "react"
+import { planningPrefsService } from "../../infrastructure/planning/PlanningPreferencesService.ts"
+
+export function usePlanningPreferences() {
+  const [prefs, setPrefs] = useState(() => planningPrefsService.load())
+
+  const setShowBreakfast = useCallback((value: boolean) => {
+    const next = { ...prefs, showBreakfast: value }
+    planningPrefsService.save(next)
+    setPrefs(next)
+  }, [prefs])
+
+  return { showBreakfast: prefs.showBreakfast, setShowBreakfast }
+}

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -970,7 +970,7 @@ export function PlanningPage() {
 
       {/* ── Dialog sélection des jours pour la liste de courses ── */}
       <Dialog open={dayPickerOpen} onOpenChange={setDayPickerOpen}>
-        <DialogContent className="max-w-sm">
+        <DialogContent className="max-w-lg">
           <DialogHeader>
             <DialogTitle>Ajouter au panier</DialogTitle>
             <DialogDescription>Sélectionnez les jours à inclure dans la liste de courses.</DialogDescription>
@@ -986,20 +986,20 @@ export function PlanningPage() {
               {selectedDays.size === pickerDays.length ? "Tout désélectionner" : "Tout sélectionner"}
             </button>
 
-            {/* Liste des jours */}
-            <div className="flex flex-col gap-1.5">
+            {/* Grille 2 colonnes × 7 lignes */}
+            <div className="grid grid-cols-2 gap-1.5">
               {pickerDays.map((day) => {
                 const dateStr = formatDate(day)
                 const dayMeals = mealPlans.filter((m) => m.date === dateStr && m.recipe)
                 const checked = selectedDays.has(dateStr)
-                const dayLabel = day.toLocaleDateString("fr-FR", { weekday: "long" })
+                const dayLabel = day.toLocaleDateString("fr-FR", { weekday: "short" })
                 const dateLabel = formatDayDate(day)
                 return (
                   <label
                     key={dateStr}
                     className={cn(
-                      "flex items-start gap-3 cursor-pointer select-none",
-                      "rounded-[var(--radius-lg)] border px-3 py-2.5 transition-colors",
+                      "flex items-center gap-2 cursor-pointer select-none",
+                      "rounded-[var(--radius-lg)] border px-2.5 py-2 transition-colors",
                       checked
                         ? "border-primary/40 bg-primary/5"
                         : "border-border/40 bg-card hover:bg-secondary/50",
@@ -1009,16 +1009,16 @@ export function PlanningPage() {
                       type="checkbox"
                       checked={checked}
                       onChange={() => toggleDay(dateStr)}
-                      className="mt-0.5 h-4 w-4 accent-[oklch(var(--color-primary))] cursor-pointer"
+                      className="h-3.5 w-3.5 shrink-0 accent-[oklch(var(--color-primary))] cursor-pointer"
                     />
-                    <div className="flex flex-col gap-0.5 min-w-0">
-                      <span className="text-sm font-semibold capitalize leading-tight">
+                    <div className="flex flex-col min-w-0">
+                      <span className="text-xs font-semibold capitalize leading-tight">
                         {dayLabel} <span className="font-normal text-muted-foreground">{dateLabel}</span>
                       </span>
                       {dayMeals.length === 0 ? (
-                        <span className="text-xs text-muted-foreground/60 italic">Aucun repas</span>
+                        <span className="text-[10px] text-muted-foreground/50 italic">Aucun repas</span>
                       ) : (
-                        <span className="text-xs text-muted-foreground truncate">
+                        <span className="text-[10px] text-muted-foreground truncate">
                           {dayMeals.map((m) => m.recipe!.name).join(" · ")}
                         </span>
                       )}

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from "../components/ui/button.tsx"
 import { usePlanning } from "../hooks/usePlanning.ts"
 import { useAddRecipesToCart } from "../hooks/useAddRecipesToCart.ts"
+import { usePlanningPreferences } from "../hooks/usePlanningPreferences.ts"
 import { RecipePickerDialog } from "../components/RecipePickerDialog.tsx"
 import { RecipeDetailModal } from "../components/RecipeDetailModal.tsx"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "../components/ui/dialog.tsx"
@@ -19,6 +20,12 @@ import { recipeImageUrl } from "../../shared/utils/image.ts"
 const DAY_LABELS = ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"]
 
 const MEAL_TYPES = [
+  {
+    key: "breakfast",
+    label: "Petit-déjeuner",
+    color: "bg-[oklch(0.97_0.014_105)] dark:bg-[oklch(0.19_0.014_100)]",
+    borderColor: "border-[oklch(0.88_0.028_105)] dark:border-[oklch(0.28_0.018_100)]",
+  },
   {
     key: "lunch",
     label: "Déjeuner",
@@ -32,6 +39,8 @@ const MEAL_TYPES = [
     borderColor: "border-[oklch(0.87_0.030_52)] dark:border-[oklch(0.26_0.018_50)]",
   },
 ] as const
+
+type MealTypeKey = (typeof MEAL_TYPES)[number]["key"]
 
 function formatDayDate(date: Date): string {
   return date.toLocaleDateString("fr-FR", { day: "numeric", month: "short" })
@@ -369,6 +378,9 @@ export function PlanningPage() {
     error: cartError,
     success: cartSuccess,
   } = useAddRecipesToCart()
+
+  const { showBreakfast } = usePlanningPreferences()
+  const mealTypes = MEAL_TYPES.filter((t) => t.key !== "breakfast" || showBreakfast)
 
   const [pickerOpen, setPickerOpen] = useState(false)
   const [pendingSlot, setPendingSlot] = useState<{ date: string; entryType: string } | null>(null)
@@ -729,7 +741,7 @@ export function PlanningPage() {
                     {formatDayDate(date)}
                   </div>
                   <div className="grid grid-cols-2 divide-x divide-border/40">
-                    {MEAL_TYPES.map(({ key, label, color }) => {
+                    {mealTypes.map(({ key, label, color }) => {
                       const dateStr = formatDate(date)
                       const meals = getMeals(date, key)
                       const isDropTarget = mobileDragOver?.date === dateStr && mobileDragOver.type === key
@@ -799,7 +811,7 @@ export function PlanningPage() {
                 </tr>
               </thead>
               <tbody>
-                {MEAL_TYPES.map(({ key, label, color, borderColor }) => (
+                {mealTypes.map(({ key, label, color, borderColor }) => (
                   <tr key={key}>
                     <td className={cn(
                       "border-b border-r border-border/50 bg-secondary/60",

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -83,12 +83,19 @@ function MobileMealSection({ meals, onAdd, onMealTouchStart }: MobileMealSection
             )}
           >
             {meal.recipe ? (
-              <img
-                src={recipeImageUrl(meal.recipe, "min-original")}
-                alt={meal.recipe.name ?? "Repas"}
-                draggable={false}
-                className="w-full aspect-square object-cover pointer-events-none"
-              />
+              <div className="relative w-full aspect-square">
+                <img
+                  src={recipeImageUrl(meal.recipe, "min-original")}
+                  alt={meal.recipe.name ?? "Repas"}
+                  draggable={false}
+                  className="w-full h-full object-cover pointer-events-none"
+                />
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-2 pb-1.5 pt-4">
+                  <span className="block text-[11px] font-semibold text-white leading-tight line-clamp-2">
+                    {meal.recipe.name}
+                  </span>
+                </div>
+              </div>
             ) : (
               <div className="w-full aspect-square bg-secondary flex items-center justify-center">
                 <span className="text-[11px] text-muted-foreground font-medium px-2 text-center">

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react"
 import { createPortal } from "react-dom"
 import {
-  ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight,
+  ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, ChevronDown,
   Plus, Loader2, AlertCircle, Copy, Eye, Trash2, ShoppingCart, CheckCircle2,
   MessageSquarePlus, MessageSquare,
 } from "lucide-react"
@@ -10,7 +10,7 @@ import { usePlanning } from "../hooks/usePlanning.ts"
 import { useAddRecipesToCart } from "../hooks/useAddRecipesToCart.ts"
 import { RecipePickerDialog } from "../components/RecipePickerDialog.tsx"
 import { RecipeDetailModal } from "../components/RecipeDetailModal.tsx"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../components/ui/dialog.tsx"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "../components/ui/dialog.tsx"
 import type { MealieMealPlan, MealieRecipe } from "../../shared/types/mealie.ts"
 import { formatDate } from "../../shared/utils/date.ts"
 import { cn } from "../../lib/utils.ts"
@@ -375,6 +375,8 @@ export function PlanningPage() {
   const [previewSlug, setPreviewSlug] = useState<string | null>(null)
   const [mobileMenuMeal, setMobileMenuMeal] = useState<{ meal: MealieMealPlan; y: number } | null>(null)
   const [noteDialog, setNoteDialog] = useState<{ meal: MealieMealPlan; value: string } | null>(null)
+  const [dayPickerOpen, setDayPickerOpen] = useState(false)
+  const [selectedDays, setSelectedDays] = useState<Set<string>>(new Set())
   const mobileMenuMealRef = useRef<((data: { meal: MealieMealPlan; y: number } | null) => void) | null>(null)
 
   // ── Mobile touch drag state ──
@@ -390,6 +392,7 @@ export function PlanningPage() {
   const [mobileDragOver, setMobileDragOver] = useState<{ date: string; type: string } | null>(null)
 
   useEffect(() => { mobileMenuMealRef.current = setMobileMenuMeal }, [])
+  useEffect(() => { if (cartSuccess && dayPickerOpen) setDayPickerOpen(false) }, [cartSuccess])
 
   const handlePreviewOpenChange = (open: boolean) => {
     if (!open) setPreviewSlug(null)
@@ -402,6 +405,32 @@ export function PlanningPage() {
     const visibleDateStrs = new Set(days.map((d) => formatDate(d)))
     const meals = mealPlans
       .filter((m) => visibleDateStrs.has(m.date) && m.recipe?.slug && m.recipe?.name)
+      .map((m) => ({ slug: m.recipe!.slug, recipeName: m.recipe!.name }))
+    await addRecipesToCart(meals)
+  }
+
+  const openDayPicker = () => {
+    setSelectedDays(new Set(days.map((d) => formatDate(d))))
+    setDayPickerOpen(true)
+  }
+
+  const toggleDay = (dateStr: string) => {
+    setSelectedDays((prev) => {
+      const next = new Set(prev)
+      if (next.has(dateStr)) next.delete(dateStr)
+      else next.add(dateStr)
+      return next
+    })
+  }
+
+  const toggleAllDays = () => {
+    const allDays = new Set(days.map((d) => formatDate(d)))
+    setSelectedDays(selectedDays.size === allDays.size ? new Set() : allDays)
+  }
+
+  const handleAddToCartWithDays = async () => {
+    const meals = mealPlans
+      .filter((m) => selectedDays.has(m.date) && m.recipe?.slug && m.recipe?.name)
       .map((m) => ({ slug: m.recipe!.slug, recipeName: m.recipe!.name }))
     await addRecipesToCart(meals)
   }
@@ -578,25 +607,37 @@ export function PlanningPage() {
           </div>
 
           <div className="flex items-center gap-2 flex-wrap">
-            {/* Ajouter au panier */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => void handleAddToCart()}
-              disabled={addingToCart}
-              className="gap-1.5"
-            >
-              {addingToCart ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : cartSuccess ? (
-                <CheckCircle2 className="h-3.5 w-3.5 text-[oklch(0.55_0.16_145)]" />
-              ) : (
-                <ShoppingCart className="h-3.5 w-3.5" />
-              )}
-              <span className="hidden sm:inline">
-                {cartSuccess ? "Ajouté !" : "Ajouter au panier"}
-              </span>
-            </Button>
+            {/* Ajouter au panier — split button */}
+            <div className="flex items-center">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleAddToCart()}
+                disabled={addingToCart}
+                className="gap-1.5 rounded-r-none border-r-0"
+              >
+                {addingToCart ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : cartSuccess ? (
+                  <CheckCircle2 className="h-3.5 w-3.5 text-[oklch(0.55_0.16_145)]" />
+                ) : (
+                  <ShoppingCart className="h-3.5 w-3.5" />
+                )}
+                <span className="hidden sm:inline">
+                  {cartSuccess ? "Ajouté !" : "Ajouter au panier"}
+                </span>
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={openDayPicker}
+                disabled={addingToCart}
+                className="rounded-l-none px-2 border-l border-border/60"
+                title="Sélectionner les jours"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </Button>
+            </div>
 
             {/* Sélecteur nombre de jours */}
             <div className={cn(
@@ -921,6 +962,88 @@ export function PlanningPage() {
             </Button>
             <Button size="sm" onClick={() => void handleSaveNote()}>
               Enregistrer
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Dialog sélection des jours pour la liste de courses ── */}
+      <Dialog open={dayPickerOpen} onOpenChange={setDayPickerOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Ajouter au panier</DialogTitle>
+            <DialogDescription>Sélectionnez les jours à inclure dans la liste de courses.</DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-2">
+            {/* Toggle tout */}
+            <button
+              type="button"
+              onClick={toggleAllDays}
+              className="self-start text-xs font-medium text-primary hover:underline"
+            >
+              {selectedDays.size === days.length ? "Tout désélectionner" : "Tout sélectionner"}
+            </button>
+
+            {/* Liste des jours */}
+            <div className="flex flex-col gap-1.5">
+              {days.map((day) => {
+                const dateStr = formatDate(day)
+                const dayMeals = mealPlans.filter((m) => m.date === dateStr && m.recipe)
+                const checked = selectedDays.has(dateStr)
+                const dayLabel = day.toLocaleDateString("fr-FR", { weekday: "long" })
+                const dateLabel = formatDayDate(day)
+                return (
+                  <label
+                    key={dateStr}
+                    className={cn(
+                      "flex items-start gap-3 cursor-pointer select-none",
+                      "rounded-[var(--radius-lg)] border px-3 py-2.5 transition-colors",
+                      checked
+                        ? "border-primary/40 bg-primary/5"
+                        : "border-border/40 bg-card hover:bg-secondary/50",
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleDay(dateStr)}
+                      className="mt-0.5 h-4 w-4 accent-[oklch(var(--color-primary))] cursor-pointer"
+                    />
+                    <div className="flex flex-col gap-0.5 min-w-0">
+                      <span className="text-sm font-semibold capitalize leading-tight">
+                        {dayLabel} <span className="font-normal text-muted-foreground">{dateLabel}</span>
+                      </span>
+                      {dayMeals.length === 0 ? (
+                        <span className="text-xs text-muted-foreground/60 italic">Aucun repas</span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground truncate">
+                          {dayMeals.map((m) => m.recipe!.name).join(" · ")}
+                        </span>
+                      )}
+                    </div>
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="ghost" size="sm" onClick={() => setDayPickerOpen(false)}>
+              Annuler
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => void handleAddToCartWithDays()}
+              disabled={selectedDays.size === 0 || addingToCart}
+              className="gap-1.5"
+            >
+              {addingToCart ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <ShoppingCart className="h-3.5 w-3.5" />
+              )}
+              Ajouter {selectedDays.size > 0 ? `${selectedDays.size} jour${selectedDays.size > 1 ? "s" : ""}` : ""}
             </Button>
           </div>
         </DialogContent>

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -400,6 +400,7 @@ export function PlanningPage() {
 
   const days = Array.from({ length: nbDays }, (_, i) => addDays(centerDate, i - 1))
   const mobileDays = Array.from({ length: nbDays }, (_, i) => addDays(centerDate, i))
+  const pickerDays = Array.from({ length: 14 }, (_, i) => addDays(new Date(), i))
 
   const handleAddToCart = async () => {
     const visibleDateStrs = new Set(days.map((d) => formatDate(d)))
@@ -410,7 +411,7 @@ export function PlanningPage() {
   }
 
   const openDayPicker = () => {
-    setSelectedDays(new Set(days.map((d) => formatDate(d))))
+    setSelectedDays(new Set(pickerDays.map((d) => formatDate(d))))
     setDayPickerOpen(true)
   }
 
@@ -424,7 +425,7 @@ export function PlanningPage() {
   }
 
   const toggleAllDays = () => {
-    const allDays = new Set(days.map((d) => formatDate(d)))
+    const allDays = new Set(pickerDays.map((d) => formatDate(d)))
     setSelectedDays(selectedDays.size === allDays.size ? new Set() : allDays)
   }
 
@@ -982,12 +983,12 @@ export function PlanningPage() {
               onClick={toggleAllDays}
               className="self-start text-xs font-medium text-primary hover:underline"
             >
-              {selectedDays.size === days.length ? "Tout désélectionner" : "Tout sélectionner"}
+              {selectedDays.size === pickerDays.length ? "Tout désélectionner" : "Tout sélectionner"}
             </button>
 
             {/* Liste des jours */}
             <div className="flex flex-col gap-1.5">
-              {days.map((day) => {
+              {pickerDays.map((day) => {
                 const dateStr = formatDate(day)
                 const dayMeals = mealPlans.filter((m) => m.date === dateStr && m.recipe)
                 const checked = selectedDays.has(dateStr)

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -411,7 +411,10 @@ export function PlanningPage() {
   }
 
   const openDayPicker = () => {
-    setSelectedDays(new Set(pickerDays.map((d) => formatDate(d))))
+    const daysWithMeals = pickerDays
+      .map((d) => formatDate(d))
+      .filter((dateStr) => mealPlans.some((m) => m.date === dateStr && m.recipe))
+    setSelectedDays(new Set(daysWithMeals))
     setDayPickerOpen(true)
   }
 

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -40,7 +40,6 @@ const MEAL_TYPES = [
   },
 ] as const
 
-type MealTypeKey = (typeof MEAL_TYPES)[number]["key"]
 
 function formatDayDate(date: Date): string {
   return date.toLocaleDateString("fr-FR", { day: "numeric", month: "short" })
@@ -411,7 +410,7 @@ export function PlanningPage() {
   const [mobileDragOver, setMobileDragOver] = useState<{ date: string; type: string } | null>(null)
 
   useEffect(() => { mobileMenuMealRef.current = setMobileMenuMeal }, [])
-  useEffect(() => { if (cartSuccess && dayPickerOpen) setDayPickerOpen(false) }, [cartSuccess])
+  useEffect(() => { if (cartSuccess && dayPickerOpen) setDayPickerOpen(false) }, [cartSuccess, dayPickerOpen])
 
   const handlePreviewOpenChange = (open: boolean) => {
     if (!open) setPreviewSlug(null)

--- a/src/presentation/pages/RecipeDetailPage.tsx
+++ b/src/presentation/pages/RecipeDetailPage.tsx
@@ -45,6 +45,7 @@ import type {
 import { SEASONS, SEASON_LABELS } from "../../shared/types/mealie.ts"
 import { getRecipeSeasonsFromTags, isSeasonTag } from "../../shared/utils/season.ts"
 import { cn } from "../../lib/utils.ts"
+import { MarkdownContent } from "../components/MarkdownContent.tsx"
 
 import { useUpdateRating } from "../../presentation/hooks/useUpdateRating"
 import { useGetFavorites } from "../../presentation/hooks/useGetFavorites"
@@ -651,6 +652,7 @@ export function RecipeDetailPage() {
               {/* Description */}
               <InlineEditText
                 value={formData.description}
+                displayValue={formData.description ? <MarkdownContent>{formData.description}</MarkdownContent> : undefined}
                 onChange={(v) => patch({ description: v })}
                 placeholder="Ajouter une description…"
                 multiline

--- a/src/presentation/pages/SettingsPage.tsx
+++ b/src/presentation/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
 import { getEnv, getIngressBasename } from "../../shared/utils/env.ts"
-import { Eye, EyeOff, CheckCircle2, XCircle, Loader2, Check, Sun, Moon, Monitor, Palette, Bot, Server, Info, Lock, AlertTriangle, LogOut, ExternalLink, Github, Globe, ChevronDown } from "lucide-react"
+import { Eye, EyeOff, CheckCircle2, XCircle, Loader2, Check, Sun, Moon, Monitor, Palette, Bot, Server, Info, Lock, AlertTriangle, LogOut, ExternalLink, Github, Globe, ChevronDown, Calendar } from "lucide-react"
 import { Button } from "../components/ui/button.tsx"
 import { Input } from "../components/ui/input.tsx"
 import { Label } from "../components/ui/label.tsx"
@@ -9,6 +9,7 @@ import { llmConfigService, getLLMEnvFields } from "../../infrastructure/llm/LLMC
 import type { LLMConfig, LLMProvider } from "../../shared/types/llm.ts"
 import { LLM_PROVIDERS } from "../../shared/types/llm.ts"
 import { useTheme } from "../hooks/useTheme.ts"
+import { usePlanningPreferences } from "../hooks/usePlanningPreferences.ts"
 import { ACCENT_COLORS } from "../../infrastructure/theme/ThemeService.ts"
 import type { Theme } from "../../infrastructure/theme/ThemeService.ts"
 import { cn } from "../../lib/utils.ts"
@@ -94,6 +95,7 @@ function CollapsibleSection({ icon, iconBg, title, subtitle, defaultOpen = false
 
 export function SettingsPage() {
   const { theme, setTheme, accentColor, setAccentColor } = useTheme()
+  const { showBreakfast, setShowBreakfast } = usePlanningPreferences()
   const navigate = useNavigate()
   const [config, setConfig] = useState<LLMConfig>(() => llmConfigService.load())
   const envFields = getLLMEnvFields()
@@ -543,6 +545,42 @@ export function SettingsPage() {
           </Button>
         </CollapsibleSection>
       )}
+
+      {/* ── Planning ── */}
+      <CollapsibleSection
+        icon={<Calendar className="h-4 w-4 text-[oklch(0.50_0.16_250)] dark:text-[oklch(0.72_0.16_250)]" />}
+        iconBg="bg-[oklch(0.93_0.05_250)] dark:bg-[oklch(0.22_0.04_250)]"
+        title="Planning"
+        subtitle="Options d'affichage du planning"
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-semibold">Petit-déjeuner</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Afficher et planifier le petit-déjeuner dans le planning
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={showBreakfast}
+            onClick={() => setShowBreakfast(!showBreakfast)}
+            className={cn(
+              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent",
+              "transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              showBreakfast ? "bg-primary" : "bg-input",
+            )}
+          >
+            <span
+              className={cn(
+                "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-lg",
+                "transform transition-transform duration-200",
+                showBreakfast ? "translate-x-4" : "translate-x-0",
+              )}
+            />
+          </button>
+        </div>
+      </CollapsibleSection>
 
       {/* ── À propos ── */}
       <CollapsibleSection


### PR DESCRIPTION
## Résumé

- **#36** — Bouton "Ajouter au panier" dans le planning : ajout d'un chevron ouvrant un sélecteur de jours (14 prochains jours, grille 2 colonnes, jours sans repas décochés par défaut)
- **#37** — Prise en charge du petit-déjeuner : toggle dans les paramètres (section Planning) pour afficher/masquer la ligne petit-déjeuner dans le planning
- **#40** — Support Markdown dans les recettes : composant `MarkdownContent` appliqué aux instructions, au mode cuisine et à la description
- **#41** — Nom des recettes invisible sur mobile : superposition du nom avec dégradé noir sur les cartes du planning mobile

## Plan de test

- [ ] Planning > clic sur le chevron du bouton panier → dialog avec les 14 prochains jours, jours sans repas décochés
- [ ] Paramètres > section Planning > activer le petit-déjeuner → ligne apparaît dans le planning
- [ ] Recette avec markdown dans les instructions → rendu formaté (gras, listes, etc.)
- [ ] Mobile > vue Planning → nom de la recette visible sur l'image

🤖 Generated with [Claude Code](https://claude.com/claude-code)