### PR TITLE
feat: mobile leftover copy & AI label button in progress bar

### DIFF
--- a/src/application/planning/usecases/AddMealUseCase.ts
+++ b/src/application/planning/usecases/AddMealUseCase.ts
@@ -11,8 +11,9 @@ export class AddMealUseCase {
   async execute(
     date: string,
     entryType: string,
-    recipeId: string,
+    recipeId?: string,
+    title?: string,
   ): Promise<MealieMealPlan> {
-    return this.planningRepository.addMeal({ date, entryType, recipeId })
+    return this.planningRepository.addMeal({ date, entryType, recipeId, title })
   }
 }

--- a/src/domain/planning/repositories/IPlanningRepository.ts
+++ b/src/domain/planning/repositories/IPlanningRepository.ts
@@ -8,7 +8,8 @@ export interface IPlanningRepository {
   addMeal(entry: {
     date: string
     entryType: string
-    recipeId: string
+    recipeId?: string
+    title?: string
   }): Promise<MealieMealPlan>
   deleteMeal(id: number): Promise<void>
   updateMealNote(meal: import("../../../shared/types/mealie.ts").MealieMealPlan, text: string): Promise<import("../../../shared/types/mealie.ts").MealieMealPlan>

--- a/src/infrastructure/mealie/repositories/PlanningRepository.ts
+++ b/src/infrastructure/mealie/repositories/PlanningRepository.ts
@@ -19,7 +19,8 @@ export class PlanningRepository implements IPlanningRepository {
   async addMeal(entry: {
     date: string
     entryType: string
-    recipeId: string
+    recipeId?: string
+    title?: string
   }): Promise<MealieMealPlan> {
     return mealieApiClient.post<MealieMealPlan>(
       "/api/households/mealplans",

--- a/src/presentation/hooks/usePlanning.ts
+++ b/src/presentation/hooks/usePlanning.ts
@@ -110,8 +110,8 @@ export function usePlanning() {
   const goToToday = () => setCenterDate(currentWeekTuesday())
   const goToTodayMobile = () => setCenterDate(today())
 
-  const addMeal = useCallback(async (date: string, entryType: string, recipeId: string) => {
-    const newMeal = await addMealUseCase.execute(date, entryType, recipeId)
+  const addMeal = useCallback(async (date: string, entryType: string, recipeId?: string, title?: string) => {
+    const newMeal = await addMealUseCase.execute(date, entryType, recipeId, title)
     setMealPlans((prev) => [...prev, newMeal])
     return newMeal
   }, [])

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -121,13 +121,6 @@ function MobileMealSection({ meals, lastMeals, onAdd, onSelectLeftover, onMealTo
     setDropdownOpen(true)
   }
 
-  useEffect(() => {
-    if (!dropdownOpen) return
-    const close = () => setDropdownOpen(false)
-    document.addEventListener("mousedown", close)
-    return () => document.removeEventListener("mousedown", close)
-  }, [dropdownOpen])
-
   return (
     <div className="flex flex-col gap-2 px-3 pb-3">
       {meals.map((meal) => {

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -110,15 +110,13 @@ function MobileMealSection({ meals, lastMeals, onAdd, onSelectLeftover, onMealTo
 
   const DROPDOWN_WIDTH = 200
   const handleCopyClick = () => {
-    if (lastMeals.length === 0) return
     const rect = copyBtnRef.current?.getBoundingClientRect()
     if (!rect) return
     const overflowsRight = rect.left + DROPDOWN_WIDTH > window.innerWidth
+    // position: fixed → coordonnées viewport, pas besoin d'ajouter scrollY/scrollX
     setDropdownPos({
-      top: rect.bottom + window.scrollY + 4,
-      left: overflowsRight
-        ? rect.right + window.scrollX - DROPDOWN_WIDTH
-        : rect.left + window.scrollX,
+      top: rect.bottom + 4,
+      left: overflowsRight ? rect.right - DROPDOWN_WIDTH : rect.left,
     })
     setDropdownOpen(true)
   }
@@ -127,11 +125,7 @@ function MobileMealSection({ meals, lastMeals, onAdd, onSelectLeftover, onMealTo
     if (!dropdownOpen) return
     const close = () => setDropdownOpen(false)
     document.addEventListener("mousedown", close)
-    document.addEventListener("touchstart", close)
-    return () => {
-      document.removeEventListener("mousedown", close)
-      document.removeEventListener("touchstart", close)
-    }
+    return () => document.removeEventListener("mousedown", close)
   }, [dropdownOpen])
 
   return (
@@ -206,57 +200,61 @@ function MobileMealSection({ meals, lastMeals, onAdd, onSelectLeftover, onMealTo
               ref={copyBtnRef}
               type="button"
               onClick={handleCopyClick}
-              disabled={lastMeals.length === 0}
-              title={
-                lastMeals.length > 0
-                  ? "Copier un repas précédent (restes)"
-                  : "Aucun repas précédent disponible"
-              }
+              title="Copier un repas précédent (restes)"
               className={cn(
                 "flex items-center justify-center rounded-[var(--radius-lg)]",
                 "border border-dashed border-border/60 px-3 py-3",
                 "text-muted-foreground hover:border-primary/60 hover:text-primary hover:bg-primary/4",
-                "disabled:cursor-not-allowed disabled:opacity-30",
                 "transition-all duration-150",
               )}
             >
               <Copy className="h-4 w-4" />
             </button>
             {dropdownOpen && dropdownPos && createPortal(
-              <div
-                className={cn(
-                  "fixed z-50 w-[200px]",
-                  "rounded-[var(--radius-lg)] border border-border/60",
-                  "bg-card shadow-lg overflow-hidden",
-                )}
-                style={{ top: dropdownPos.top, left: dropdownPos.left }}
-                onMouseDown={(e) => e.stopPropagation()}
-                onTouchStart={(e) => e.stopPropagation()}
-              >
-                {lastMeals.map((meal) => (
-                  <button
-                    key={meal.id}
-                    type="button"
-                    onClick={() => { setDropdownOpen(false); onSelectLeftover(meal) }}
-                    className={cn(
-                      "flex items-center gap-2 w-full px-2 py-1.5 text-left",
-                      "text-sm hover:bg-accent hover:text-accent-foreground",
-                      "transition-colors",
-                    )}
-                  >
-                    {meal.recipe && (
-                      <img
-                        src={recipeImageUrl(meal.recipe, "min-original")}
-                        alt=""
-                        className="h-8 w-8 shrink-0 rounded-[var(--radius-sm)] object-cover"
-                      />
-                    )}
-                    <span className="line-clamp-2 leading-snug">
-                      {meal.recipe?.name ?? meal.title ?? "Sans titre"}
-                    </span>
-                  </button>
-                ))}
-              </div>,
+              <>
+                <div
+                  className="fixed inset-0 z-40"
+                  onClick={() => setDropdownOpen(false)}
+                />
+                <div
+                  className={cn(
+                    "fixed z-50 w-[200px]",
+                    "rounded-[var(--radius-lg)] border border-border/60",
+                    "bg-card shadow-lg overflow-hidden",
+                  )}
+                  style={{ top: dropdownPos.top, left: dropdownPos.left }}
+                >
+                  {lastMeals.length === 0 ? (
+                    <p className="px-3 py-2.5 text-xs text-muted-foreground">
+                      Aucun repas précédent disponible
+                    </p>
+                  ) : (
+                    lastMeals.map((meal) => (
+                      <button
+                        key={meal.id}
+                        type="button"
+                        onClick={() => { setDropdownOpen(false); onSelectLeftover(meal) }}
+                        className={cn(
+                          "flex items-center gap-2 w-full px-2 py-1.5 text-left",
+                          "text-sm hover:bg-accent hover:text-accent-foreground",
+                          "transition-colors",
+                        )}
+                      >
+                        {meal.recipe && (
+                          <img
+                            src={recipeImageUrl(meal.recipe, "min-original")}
+                            alt=""
+                            className="h-8 w-8 shrink-0 rounded-[var(--radius-sm)] object-cover"
+                          />
+                        )}
+                        <span className="line-clamp-2 leading-snug">
+                          {meal.recipe?.name ?? meal.title ?? "Sans titre"}
+                        </span>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </>,
               document.body,
             )}
           </>

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -95,12 +95,45 @@ async function fetchAllRecipes(): Promise<MealieRecipe[]> {
 
 interface MobileMealSectionProps {
   meals: MealieMealPlan[]
+  lastMeals: MealieMealPlan[]
   onAdd: () => void
+  onSelectLeftover: (meal: MealieMealPlan) => void
   onMealTouchStart: (meal: MealieMealPlan, e: React.TouchEvent) => void
   servingsEnabled: boolean
 }
 
-function MobileMealSection({ meals, onAdd, onMealTouchStart, servingsEnabled }: MobileMealSectionProps) {
+function MobileMealSection({ meals, lastMeals, onAdd, onSelectLeftover, onMealTouchStart, servingsEnabled }: MobileMealSectionProps) {
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null)
+  const copyBtnRef = useRef<HTMLButtonElement>(null)
+  const isEmpty = meals.length === 0
+
+  const DROPDOWN_WIDTH = 200
+  const handleCopyClick = () => {
+    if (lastMeals.length === 0) return
+    const rect = copyBtnRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const overflowsRight = rect.left + DROPDOWN_WIDTH > window.innerWidth
+    setDropdownPos({
+      top: rect.bottom + window.scrollY + 4,
+      left: overflowsRight
+        ? rect.right + window.scrollX - DROPDOWN_WIDTH
+        : rect.left + window.scrollX,
+    })
+    setDropdownOpen(true)
+  }
+
+  useEffect(() => {
+    if (!dropdownOpen) return
+    const close = () => setDropdownOpen(false)
+    document.addEventListener("mousedown", close)
+    document.addEventListener("touchstart", close)
+    return () => {
+      document.removeEventListener("mousedown", close)
+      document.removeEventListener("touchstart", close)
+    }
+  }, [dropdownOpen])
+
   return (
     <div className="flex flex-col gap-2 px-3 pb-3">
       {meals.map((meal) => {
@@ -152,19 +185,83 @@ function MobileMealSection({ meals, onAdd, onMealTouchStart, servingsEnabled }: 
           </div>
         )
       })}
-      <button
-        type="button"
-        onClick={onAdd}
-        aria-label="Ajouter un repas"
-        className={cn(
-          "flex w-full items-center justify-center rounded-[var(--radius-lg)]",
-          "border border-dashed border-border/60 py-3",
-          "text-muted-foreground hover:border-primary/60 hover:text-primary hover:bg-primary/4",
-          "transition-all duration-150",
+      <div className="flex gap-1.5">
+        <button
+          type="button"
+          onClick={onAdd}
+          aria-label="Ajouter un repas"
+          className={cn(
+            "flex flex-1 items-center justify-center rounded-[var(--radius-lg)]",
+            "border border-dashed border-border/60 py-3",
+            "text-muted-foreground hover:border-primary/60 hover:text-primary hover:bg-primary/4",
+            "transition-all duration-150",
+          )}
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+
+        {isEmpty && (
+          <>
+            <button
+              ref={copyBtnRef}
+              type="button"
+              onClick={handleCopyClick}
+              disabled={lastMeals.length === 0}
+              title={
+                lastMeals.length > 0
+                  ? "Copier un repas précédent (restes)"
+                  : "Aucun repas précédent disponible"
+              }
+              className={cn(
+                "flex items-center justify-center rounded-[var(--radius-lg)]",
+                "border border-dashed border-border/60 px-3 py-3",
+                "text-muted-foreground hover:border-primary/60 hover:text-primary hover:bg-primary/4",
+                "disabled:cursor-not-allowed disabled:opacity-30",
+                "transition-all duration-150",
+              )}
+            >
+              <Copy className="h-4 w-4" />
+            </button>
+            {dropdownOpen && dropdownPos && createPortal(
+              <div
+                className={cn(
+                  "fixed z-50 w-[200px]",
+                  "rounded-[var(--radius-lg)] border border-border/60",
+                  "bg-card shadow-lg overflow-hidden",
+                )}
+                style={{ top: dropdownPos.top, left: dropdownPos.left }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onTouchStart={(e) => e.stopPropagation()}
+              >
+                {lastMeals.map((meal) => (
+                  <button
+                    key={meal.id}
+                    type="button"
+                    onClick={() => { setDropdownOpen(false); onSelectLeftover(meal) }}
+                    className={cn(
+                      "flex items-center gap-2 w-full px-2 py-1.5 text-left",
+                      "text-sm hover:bg-accent hover:text-accent-foreground",
+                      "transition-colors",
+                    )}
+                  >
+                    {meal.recipe && (
+                      <img
+                        src={recipeImageUrl(meal.recipe, "min-original")}
+                        alt=""
+                        className="h-8 w-8 shrink-0 rounded-[var(--radius-sm)] object-cover"
+                      />
+                    )}
+                    <span className="line-clamp-2 leading-snug">
+                      {meal.recipe?.name ?? meal.title ?? "Sans titre"}
+                    </span>
+                  </button>
+                ))}
+              </div>,
+              document.body,
+            )}
+          </>
         )}
-      >
-        <Plus className="h-4 w-4" />
-      </button>
+      </div>
     </div>
   )
 }
@@ -976,7 +1073,9 @@ export function PlanningPage() {
                           </div>
                           <MobileMealSection
                             meals={meals}
+                            lastMeals={getLastMeals(date, key, 3)}
                             onAdd={() => handleAddMeal(dateStr, key)}
+                            onSelectLeftover={(meal) => void handleLeftoverSelect(date, key, meal)}
                             onMealTouchStart={handleMealTouchStart}
                             servingsEnabled={flags.servings}
                           />

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -657,7 +657,7 @@ export function PlanningPage() {
 
   const getLastMeals = (date: Date, type: string, count: number): MealieMealPlan[] => {
     const result: MealieMealPlan[] = []
-    const seenIds = new Set<string>()
+    const seenKeys = new Set<string>()
     let currentDate = date
     let currentType = type
     for (let i = 0; i < count * 8 && result.length < count; i++) {
@@ -670,8 +670,9 @@ export function PlanningPage() {
       const key = formatDate(currentDate)
       const slots = mealPlans.filter((m) => m.date === key && m.entryType === currentType)
       for (const meal of slots) {
-        if (meal.recipe && !seenIds.has(meal.recipe.id)) {
-          seenIds.add(meal.recipe.id)
+        const uniqueKey = meal.recipe?.id ?? meal.title ?? ""
+        if (uniqueKey && !seenKeys.has(uniqueKey)) {
+          seenKeys.add(uniqueKey)
           result.push(meal)
           if (result.length >= count) break
         }
@@ -749,8 +750,9 @@ export function PlanningPage() {
   }
 
   const handleLeftoverSelect = async (date: Date, entryType: string, meal: MealieMealPlan) => {
-    if (!meal.recipe) return
-    const newMeal = await addMeal(formatDate(date), entryType, meal.recipe.id)
+    const newMeal = meal.recipe
+      ? await addMeal(formatDate(date), entryType, meal.recipe.id)
+      : await addMeal(formatDate(date), entryType, undefined, meal.title)
     const servings = getMealServings(meal)
     if (servings) {
       await updateMealNote(newMeal, encodeServingsInText(servings, getMealVisibleNote(newMeal)))

--- a/src/presentation/pages/SettingsPage.tsx
+++ b/src/presentation/pages/SettingsPage.tsx
@@ -224,7 +224,6 @@ export function SettingsPage() {
         iconBg="bg-primary/8"
         title="Apparence"
         subtitle="Thème et couleur d'accent"
-        defaultOpen
       >
         <div className="space-y-2.5">
           <Label>Thème</Label>
@@ -285,13 +284,114 @@ export function SettingsPage() {
         </div>
       </CollapsibleSection>
 
+      {/* ── Planning ── */}
+      <CollapsibleSection
+        icon={<Calendar className="h-4 w-4 text-[oklch(0.50_0.16_250)] dark:text-[oklch(0.72_0.16_250)]" />}
+        iconBg="bg-[oklch(0.93_0.05_250)] dark:bg-[oklch(0.22_0.04_250)]"
+        title="Planning"
+        subtitle="Repas, foyer et options d'affichage"
+      >
+        <div className="space-y-2.5">
+          <Label>Taille du foyer</Label>
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => setFamilySize(familySize - 1)}
+              disabled={familySize <= 1}
+              aria-label="Diminuer la taille du foyer"
+            >
+              <Minus className="h-4 w-4" />
+            </Button>
+            <Input
+              type="number"
+              min={1}
+              max={99}
+              value={familySize}
+              onChange={(e) => setFamilySize(Number(e.target.value || 1))}
+              className="w-24 text-center font-semibold"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => setFamilySize(familySize + 1)}
+              disabled={familySize >= 99}
+              aria-label="Augmenter la taille du foyer"
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+            <span className="text-sm text-muted-foreground">personnes</span>
+          </div>
+        </div>
+
+        <div className="divide-y divide-border">
+          <div className="flex items-center justify-between py-3 px-1">
+            <div>
+              <p className="text-sm font-medium">Petit-déjeuner</p>
+              <p className="text-xs text-muted-foreground">
+                Afficher et planifier le petit-déjeuner dans le planning
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showBreakfast}
+              onClick={() => setShowBreakfast(!showBreakfast)}
+              className={cn(
+                "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent",
+                "transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                showBreakfast ? "bg-primary" : "bg-input",
+              )}
+            >
+              <span
+                className={cn(
+                  "pointer-events-none inline-block h-4 w-4 rounded-full bg-background shadow-lg",
+                  "transform transition-transform duration-200",
+                  showBreakfast ? "translate-x-4" : "translate-x-0",
+                )}
+              />
+            </button>
+          </div>
+          <FeatureRow
+            label="Système de portions"
+            description="Permet d'ajuster le nombre de portions dans le planning"
+            enabled={flags.servings}
+            onChange={(v) => setFlag("servings", v)}
+          />
+          <FeatureRow
+            label="Auto-planification"
+            description="Suggère automatiquement des recettes pour compléter la semaine"
+            enabled={flags.autoPlan}
+            onChange={(v) => setFlag("autoPlan", v)}
+          />
+        </div>
+      </CollapsibleSection>
+
+      {/* ── Recettes ── */}
+      <CollapsibleSection
+        icon={<Sliders className="h-4 w-4 text-[oklch(0.50_0.14_160)] dark:text-[oklch(0.72_0.14_160)]" />}
+        iconBg="bg-[oklch(0.93_0.04_160)] dark:bg-[oklch(0.22_0.04_160)]"
+        title="Recettes"
+        subtitle="Options d'affichage des recettes"
+      >
+        <div className="divide-y divide-border">
+          <FeatureRow
+            label="Calcul nutritionnel"
+            description="Affiche les calories et protéines sur les recettes"
+            enabled={flags.nutrition}
+            onChange={(v) => setFlag("nutrition", v)}
+          />
+        </div>
+      </CollapsibleSection>
+
       {/* ── Fournisseur IA ── */}
       <CollapsibleSection
         icon={<Bot className="h-4 w-4 text-[oklch(0.50_0.14_290)] dark:text-[oklch(0.72_0.14_290)]" />}
         iconBg="bg-[oklch(0.93_0.04_290)] dark:bg-[oklch(0.22_0.04_290)]"
         title="Fournisseur IA"
         subtitle={envFields.size > 0 ? "Certains paramètres via variables d'environnement" : `${LLM_PROVIDERS[config.provider].label} — ${config.model || 'non configuré'}`}
-        defaultOpen={!llmConfigService.isConfigured()}
         headerExtra={
           <a
             href="https://bonap.aylabs.fr/docs/configuration/llm"
@@ -596,108 +696,6 @@ export function SettingsPage() {
               className="bg-secondary/40 font-mono text-xs"
             />
           </div>
-        </div>
-      </CollapsibleSection>
-
-      {/* ── Planning ── */}
-      <CollapsibleSection
-        icon={<Calendar className="h-4 w-4 text-[oklch(0.50_0.16_250)] dark:text-[oklch(0.72_0.16_250)]" />}
-        iconBg="bg-[oklch(0.93_0.05_250)] dark:bg-[oklch(0.22_0.04_250)]"
-        title="Planning"
-        subtitle="Repas, foyer et options d'affichage"
-      >
-        <div className="space-y-2.5">
-          <Label>Taille du foyer</Label>
-          <div className="flex items-center gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              onClick={() => setFamilySize(familySize - 1)}
-              disabled={familySize <= 1}
-              aria-label="Diminuer la taille du foyer"
-            >
-              <Minus className="h-4 w-4" />
-            </Button>
-            <Input
-              type="number"
-              min={1}
-              max={99}
-              value={familySize}
-              onChange={(e) => setFamilySize(Number(e.target.value || 1))}
-              className="w-24 text-center font-semibold"
-            />
-            <Button
-              type="button"
-              variant="outline"
-              size="icon"
-              onClick={() => setFamilySize(familySize + 1)}
-              disabled={familySize >= 99}
-              aria-label="Augmenter la taille du foyer"
-            >
-              <Plus className="h-4 w-4" />
-            </Button>
-            <span className="text-sm text-muted-foreground">personnes</span>
-          </div>
-        </div>
-
-        <div className="divide-y divide-border">
-          <div className="flex items-center justify-between py-3 px-1">
-            <div>
-              <p className="text-sm font-medium">Petit-déjeuner</p>
-              <p className="text-xs text-muted-foreground">
-                Afficher et planifier le petit-déjeuner dans le planning
-              </p>
-            </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={showBreakfast}
-              onClick={() => setShowBreakfast(!showBreakfast)}
-              className={cn(
-                "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent",
-                "transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                showBreakfast ? "bg-primary" : "bg-input",
-              )}
-            >
-              <span
-                className={cn(
-                  "pointer-events-none inline-block h-4 w-4 rounded-full bg-background shadow-lg",
-                  "transform transition-transform duration-200",
-                  showBreakfast ? "translate-x-4" : "translate-x-0",
-                )}
-              />
-            </button>
-          </div>
-          <FeatureRow
-            label="Système de portions"
-            description="Permet d'ajuster le nombre de portions dans le planning"
-            enabled={flags.servings}
-            onChange={(v) => setFlag("servings", v)}
-          />
-          <FeatureRow
-            label="Auto-planification"
-            description="Suggère automatiquement des recettes pour compléter la semaine"
-            enabled={flags.autoPlan}
-            onChange={(v) => setFlag("autoPlan", v)}
-          />
-        </div>
-      </CollapsibleSection>
-
-      {/* ── Recettes ── */}
-      <CollapsibleSection
-        icon={<Sliders className="h-4 w-4 text-[oklch(0.50_0.14_160)] dark:text-[oklch(0.72_0.14_160)]" />}
-        iconBg="bg-[oklch(0.93_0.04_160)] dark:bg-[oklch(0.22_0.04_160)]"
-        title="Recettes"
-        subtitle="Options d'affichage des recettes"
-      >
-        <div className="divide-y divide-border">
-          <FeatureRow
-            label="Calcul nutritionnel"
-            description="Affiche les calories et protéines sur les recettes"
-            enabled={flags.nutrition}
-            onChange={(v) => setFlag("nutrition", v)}
-          />
         </div>
       </CollapsibleSection>
 

--- a/src/presentation/pages/ShoppingPage.tsx
+++ b/src/presentation/pages/ShoppingPage.tsx
@@ -486,11 +486,9 @@ interface GroupHeaderProps {
   label: string
   color?: string
   isFirst?: boolean
-  onAiCategorize?: () => void
-  aiCategorizeLoading?: boolean
 }
 
-function GroupHeader({ label, isFirst, onAiCategorize, aiCategorizeLoading }: GroupHeaderProps) {
+function GroupHeader({ label, isFirst }: GroupHeaderProps) {
   const isNone = label === "Sans étiquette"
   return (
     <div className={cn(
@@ -504,21 +502,6 @@ function GroupHeader({ label, isFirst, onAiCategorize, aiCategorizeLoading }: Gr
       <span className="text-[9.5px] font-bold uppercase tracking-[0.10em] text-muted-foreground/60">
         {label}
       </span>
-      {onAiCategorize && (
-        <button
-          type="button"
-          onClick={onAiCategorize}
-          disabled={aiCategorizeLoading}
-          title="Catégoriser via IA"
-          className="ml-auto flex items-center gap-1 rounded-full px-2 py-0.5 text-[9.5px] font-semibold uppercase tracking-[0.10em] text-muted-foreground/60 hover:text-primary hover:bg-primary/10 transition-colors disabled:opacity-50"
-        >
-          {aiCategorizeLoading
-            ? <Loader2 className="h-3 w-3 animate-spin" />
-            : <Sparkles className="h-3 w-3" />
-          }
-          IA
-        </button>
-      )}
     </div>
   )
 }
@@ -533,8 +516,6 @@ interface GroupedItemsProps {
   onUpdateQuantity: (item: ShoppingItem, qty: number) => void
   onUpdateNote: (item: ShoppingItem, note: string) => void
   onUpdateLabel: (item: ShoppingItem, labelId: string | undefined) => void
-  onAiCategorize?: (uncategorizedItems: ShoppingItem[]) => void
-  aiCategorizeLoading?: boolean
   onViewRecipe?: (recipeName: string) => void
 }
 
@@ -543,7 +524,7 @@ function itemSortKey(item: ShoppingItem): string {
   return (item.foodName ?? note).toLowerCase()
 }
 
-function GroupedItems({ items, labels, onToggle, onDelete, onUpdateQuantity, onUpdateNote, onUpdateLabel, onAiCategorize, aiCategorizeLoading, onViewRecipe }: GroupedItemsProps) {
+function GroupedItems({ items, labels, onToggle, onDelete, onUpdateQuantity, onUpdateNote, onUpdateLabel, onViewRecipe }: GroupedItemsProps) {
   const unchecked = items.filter((i) => !i.checked)
   const checked = items.filter((i) => i.checked)
 
@@ -587,12 +568,7 @@ function GroupedItems({ items, labels, onToggle, onDelete, onUpdateQuantity, onU
       {uncheckedGroups.map(([key, group]) => (
         <div key={key}>
           {uncheckedGroups.length > 1 && (
-            <GroupHeader
-              label={group.label}
-              color={group.color}
-              onAiCategorize={key === "__none__" && onAiCategorize ? () => onAiCategorize(group.items) : undefined}
-              aiCategorizeLoading={key === "__none__" ? aiCategorizeLoading : undefined}
-            />
+            <GroupHeader label={group.label} color={group.color} />
           )}
           <ul>
             {group.items.map((item) => (
@@ -906,12 +882,29 @@ export function ShoppingPage() {
             </div>
 
             <div className="rounded-[var(--radius-2xl)] border border-border/50 bg-card shadow-subtle">
-              {/* Barre de progression */}
+              {/* Barre de progression + bouton IA */}
               {totalCount > 0 && (
                 <div className="px-4 pt-3 pb-2">
                   <div className="flex items-center justify-between mb-1.5">
                     <span className="text-xs font-medium text-muted-foreground">{progressPct}% complété</span>
-                    <span className="text-xs text-muted-foreground">{checkedCount}/{totalCount}</span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground">{checkedCount}/{totalCount}</span>
+                      {labels.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={() => void handleAiCategorize(items.filter((i) => !i.checked && !i.label))}
+                          disabled={aiLoading || items.filter((i) => !i.checked && !i.label).length === 0}
+                          title="Catégoriser les articles sans étiquette via IA"
+                          className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[9.5px] font-semibold uppercase tracking-[0.10em] text-muted-foreground/60 hover:text-primary hover:bg-primary/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                        >
+                          {aiLoading
+                            ? <Loader2 className="h-3 w-3 animate-spin" />
+                            : <Sparkles className="h-3 w-3" />
+                          }
+                          IA
+                        </button>
+                      )}
+                    </div>
                   </div>
                   <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
                     <div
@@ -930,8 +923,6 @@ export function ShoppingPage() {
                 onUpdateQuantity={(item, qty) => void updateItemQuantity(item, qty)}
                 onUpdateNote={(item, note) => void updateItemNote(item, note)}
                 onUpdateLabel={(item, labelId) => void updateItemLabel(item, labelId)}
-                onAiCategorize={labels.length > 0 ? (uncategorized) => void handleAiCategorize(uncategorized) : undefined}
-                aiCategorizeLoading={aiLoading}
                 onViewRecipe={(name) => void handleViewRecipe(name)}
               />
 


### PR DESCRIPTION
## Summary

- **Settings** : réorganisation des sections (Apparence → Planning → Recettes → IA → Mealie → À propos) et fermeture par défaut de toutes les sections
- **Planning mobile** : ajout du bouton copie (restes) sur les créneaux vides en vue mobile — support des repas avec et sans recette liée
- **Courses** : déplacement du bouton IA étiquettes dans la barre de progression (toujours visible, plus besoin d'aller chercher le groupe "Sans étiquette")

Closes #49
Closes #48

## Test plan

- [ ] Ouvrir les paramètres : toutes les sections sont fermées, ordre correct
- [ ] Planning mobile : créneau vide → bouton copie visible à côté du `+`
- [ ] Planning mobile : cliquer le bouton copie → dropdown avec les repas précédents
- [ ] Planning mobile : sélectionner un repas dans le dropdown → repas ajouté au créneau
- [ ] Planning mobile : bouton copie sans repas précédents → dropdown "Aucun repas précédent disponible"
- [ ] Courses : bouton IA visible à droite du compteur dans la barre de progression
- [ ] Courses : bouton IA désactivé si tous les articles sont déjà étiquetés

🤖 Generated with [Claude Code](https://claude.com/claude-code)