### PR TITLE
fix(recipes): affiche les images sans dépendre du champ recipe.image

### DIFF
--- a/src/presentation/components/RecipeCard.tsx
+++ b/src/presentation/components/RecipeCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { Link } from "react-router-dom"
 import { SeasonBadge } from "./SeasonBadge.tsx"
 import type { MealieRecipe } from "../../shared/types/mealie.ts"
@@ -12,7 +13,8 @@ interface RecipeCardProps {
 }
 
 export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
-  const imageUrl = recipe.image ? recipeImageUrl(recipe, "min-original") : null
+  const [imgError, setImgError] = useState(false)
+  const imageUrl = recipeImageUrl(recipe, "min-original")
   const seasons = getRecipeSeasonsFromTags(recipe.tags)
   const categories = recipe.recipeCategory ?? []
 
@@ -33,10 +35,11 @@ export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
       >
         {/* Image carrée */}
         <div className="relative aspect-square w-full overflow-hidden bg-muted">
-          {imageUrl ? (
+          {!imgError ? (
             <img
               src={imageUrl}
               alt={recipe.name}
+              onError={() => setImgError(true)}
               className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
             />
           ) : (

--- a/src/presentation/pages/RecipeDetailPage.tsx
+++ b/src/presentation/pages/RecipeDetailPage.tsx
@@ -167,7 +167,7 @@ export function RecipeDetailPage() {
   // Initialise formData once recipe is loaded
   if (recipe && !formData) {
     setFormData(buildFormData(recipe))
-    if (recipe.image) setImagePreview(recipeImageUrl(recipe, "original"))
+    setImagePreview(recipeImageUrl(recipe, "original"))
   }
 
   // Take Favorite
@@ -537,6 +537,7 @@ export function RecipeDetailPage() {
                     <img
                       src={imagePreview}
                       alt={recipe.name}
+                      onError={() => setImagePreview(null)}
                       className="aspect-video w-full object-cover"
                     />
                     <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/30">


### PR DESCRIPTION
## Summary

- **RecipeCard** : charge toujours l'image via `recipe.id` (sans gater sur `recipe.image`), fallback emoji 🍽️ via `onError` si 404
- **RecipeDetailPage** : initialise `imagePreview` systématiquement au chargement de la recette, `onError` qui repasse sur le placeholder "Cliquer pour ajouter une photo"

## Cause racine

L'API Mealie ne retourne pas le champ `image` dans les réponses de liste (`GET /api/recipes`). `recipe.image` était donc toujours `undefined` côté catalogue, empêchant l'affichage des photos. `RecipeDrawer` n'avait pas ce bug car il ne gatait pas sur ce champ.

## Test plan

- [ ] Les recettes avec photo affichent bien leur image dans le catalogue
- [ ] Les recettes sans photo affichent l'emoji placeholder dans le catalogue
- [ ] Sur la page complète, les recettes avec photo affichent l'image
- [ ] Sur la page complète, les recettes sans photo affichent le placeholder "Cliquer pour ajouter une photo"

🤖 Generated with [Claude Code](https://claude.com/claude-code)