### PR TITLE
fix: nutrition estimate 405, servings sync and ollama-proxy wildcard

### DIFF
--- a/ha-addon/bonap-bff.cjs
+++ b/ha-addon/bonap-bff.cjs
@@ -1266,7 +1266,7 @@ app.get('/ciqual/search', async (req, res) => {
   }
 })
 
-app.post('/nutrition-estimate', async (req, res) => {
+async function handleNutritionEstimate(req, res) {
   try {
     const ingredients = Array.isArray(req.body?.ingredients) ? req.body.ingredients : []
     const rawMatchHints = (req.body?.matchHints && typeof req.body.matchHints === 'object') ? req.body.matchHints : {}
@@ -1381,7 +1381,12 @@ app.post('/nutrition-estimate', async (req, res) => {
     console.error('[Nutrition] Estimate error:', e.message)
     res.status(500).json({ error: e.message })
   }
-})
+}
+
+// Current path used by the frontend
+app.post('/nutrition-estimate', handleNutritionEstimate)
+// Backwards-compatible alias: old frontend builds used /marmiton/nutrition-estimate
+app.post('/marmiton/nutrition-estimate', handleNutritionEstimate)
 
 // Call Ollama server-side to extract a recipe from text
 // Returns { data, error } to provide explicit diagnostics back to the UI.
@@ -1634,14 +1639,14 @@ function isPrivateOrLocalUrl(rawUrl) {
   }
 }
 
-app.all('/ollama-proxy/*path', async (req, res) => {
+app.all('/ollama-proxy/*', async (req, res) => {
   const target = req.headers['x-ollama-target']
   if (typeof target !== 'string' || !isPrivateOrLocalUrl(target)) {
     return res
       .status(400)
       .json({ error: 'X-Ollama-Target manquant ou non autorisé (réseau local uniquement)' })
   }
-  const subpath = req.params.path ?? ''
+  const subpath = req.params[0] ?? ''
   const url = `${target.replace(/\/+$/, '')}/${subpath}`
   try {
     const hasBody = req.method !== 'GET' && req.method !== 'HEAD'

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,6 +16,18 @@ server {
         proxy_read_timeout 120s;
     }
 
+    # Backwards-compatible alias: old frontend builds used /api/marmiton/* instead of /api/bonap/*
+    location ^~ /api/marmiton/ {
+        rewrite ^/api/marmiton/(.*) /$1 break;
+        proxy_pass http://127.0.0.1:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host 127.0.0.1;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 120s;
+    }
+
     # Proxy Ollama local (utile si l'UI utilise /api/ollama)
     location ^~ /api/ollama/ {
         resolver 127.0.0.11 valid=10s;

--- a/src/infrastructure/mealie/repositories/RecipeRepository.ts
+++ b/src/infrastructure/mealie/repositories/RecipeRepository.ts
@@ -188,6 +188,8 @@ export class RecipeRepository implements IRecipeRepository {
       // Strip any leading number that may have been stored by a previous buggy save.
       recipeYield: current.recipeYield ? (current.recipeYield.replace(/^\d+\s*/, '').trim() || "") : current.recipeYield,
       recipeServings: data.recipeYield ? parseFloat(data.recipeYield) : (current.recipeServings ?? 0),
+      // recipeYieldQuantity mirrors recipeServings for Mealie UI display (yield quantity field).
+      recipeYieldQuantity: data.recipeYield ? parseFloat(data.recipeYield) : (current.recipeYieldQuantity ?? 0),
       recipeCategory: data.categories.map((c) => {
         const orig = current.recipeCategory?.find((rc) => rc.id === c.id)
         return orig ? { ...orig, ...c } : c


### PR DESCRIPTION
- BFF: extract handleNutritionEstimate and register it on both POST /nutrition-estimate and POST /marmiton/nutrition-estimate (backwards-compatible alias for old cached frontend builds)
- nginx: add location ^~ /api/marmiton/ block before the generic /api/ proxy so old /api/marmiton/* requests reach the BFF instead of Mealie (which returned 405 Method Not Allowed)
- BFF: fix /ollama-proxy/* wildcard route from Express v5 syntax (/*path + req.params.path) to Express v4 syntax (/* + req.params[0]) — route was never matched, causing 404 on /api/bonap/ollama-proxy/**
- RecipeRepository: also update recipeYieldQuantity when saving servings so Mealie UI shows the correct portion count instead of writing only to recipeServings (which Mealie does not display)

## Description

<!-- Décrivez les changements apportés et pourquoi -->

## Type de changement

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring (pas de changement de comportement)
- [ ] Documentation
- [ ] Maintenance (deps, CI, config...)

## Tests

- [ ] `npm run lint` passe sans erreur
- [ ] `npm run build` passe sans erreur
- [ ] Testé manuellement sur une instance Mealie
- [ ] Tests e2e passent (`npx playwright test`) — si applicable

## Checklist

- [ ] La branche est créée depuis `main` (pas de push direct sur `main`)
- [ ] Les commits suivent la convention `type(scope): message`
- [ ] La PR pointe vers `main`
