### PR TITLE
feat(recipes): repas simples, emojis, filtre tag simple (#89)

### DIFF
--- a/e2e/kiosk.spec.ts
+++ b/e2e/kiosk.spec.ts
@@ -96,7 +96,7 @@ test.describe("Mode Kiosk", () => {
             description: "",
             image: null,
             tags: [{ id: "tag-simple", name: "simple", slug: "simple" }],
-            extras: { emoji: "🍳" },
+            extras: { bonap_emoji: "🍳" },
           },
         },
       ],
@@ -109,6 +109,9 @@ test.describe("Mode Kiosk", () => {
       } else {
         await route.continue()
       }
+    })
+    await page.route("**/api/recipes/tomates-oeufs", async (route) => {
+      await route.fulfill({ json: simpleRecipeMeal.items[0].recipe })
     })
 
     await page.goto("/kiosk")

--- a/e2e/kiosk.spec.ts
+++ b/e2e/kiosk.spec.ts
@@ -113,10 +113,13 @@ test.describe("Mode Kiosk", () => {
     await page.route("**/api/recipes/tomates-oeufs", async (route) => {
       await route.fulfill({ json: simpleRecipeMeal.items[0].recipe })
     })
+    // Déclenche onError immédiatement pour afficher le fallback emoji
+    await page.route("**/api/media/recipes/**", async (route) => {
+      await route.fulfill({ status: 404, body: "" })
+    })
 
     await page.goto("/kiosk")
     await expect(page.getByText("tomates, oeufs")).toBeVisible()
-    // L'emoji doit apparaître dans le fallback image
-    await expect(page.getByText("🍳")).toBeVisible()
+    await expect(page.getByText("🍳")).toBeVisible({ timeout: 8000 })
   })
 })

--- a/e2e/kiosk.spec.ts
+++ b/e2e/kiosk.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "@playwright/test"
+import { setAuthToken, mockAllApiRoutes } from "./helpers/mockApi.ts"
+import { MEALPLANS_RESPONSE } from "./fixtures/mealie.ts"
+
+test.describe("Mode Kiosk", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await setAuthToken(page)
+    await mockAllApiRoutes(page)
+  })
+
+  test("affiche l'heure et la date courantes dans le header", async ({ page }) => {
+    await page.goto("/kiosk")
+    // L'heure est affichée en format HH:MM
+    await expect(page.locator("p.tabular-nums")).toBeVisible()
+    const timeText = await page.locator("p.tabular-nums").innerText()
+    expect(timeText).toMatch(/^\d{2}:\d{2}$/)
+  })
+
+  test("affiche une colonne par jour du planning", async ({ page }) => {
+    await page.goto("/kiosk")
+    // Par défaut kioskDays=5, donc 5 colonnes jour
+    // Chaque colonne a un label (Aujourd'hui, Demain, etc.)
+    await expect(page.getByText("Aujourd'hui")).toBeVisible()
+    await expect(page.getByText("Demain")).toBeVisible()
+  })
+
+  test("affiche les créneaux Déjeuner et Dîner", async ({ page }) => {
+    await page.goto("/kiosk")
+    const lunchSlots = page.getByText("Déjeuner")
+    const dinnerSlots = page.getByText("Dîner")
+    await expect(lunchSlots.first()).toBeVisible()
+    await expect(dinnerSlots.first()).toBeVisible()
+  })
+
+  test("affiche les recettes du planning dans les créneaux", async ({ page }) => {
+    await page.goto("/kiosk")
+    await expect(page.getByText("Pizza maison")).toBeVisible()
+    await expect(page.getByText("Salade niçoise")).toBeVisible()
+  })
+
+  test("affiche 'Rien de prévu' pour les créneaux vides", async ({ page }) => {
+    await page.goto("/kiosk")
+    await expect(page.getByText("Rien de prévu").first()).toBeVisible()
+  })
+
+  test("le bouton rafraîchir déclenche un nouvel appel API", async ({ page }) => {
+    let callCount = 0
+    await page.route("**/api/households/mealplans**", async (route) => {
+      if (route.request().method() === "GET") {
+        callCount++
+        await route.fulfill({ json: MEALPLANS_RESPONSE })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.goto("/kiosk")
+    const initialCount = callCount
+    await page.getByTitle("Rafraîchir").click()
+    // Attendre que le deuxième appel soit fait
+    await page.waitForTimeout(500)
+    expect(callCount).toBeGreaterThan(initialCount)
+  })
+
+  test("le créneau prochain est mis en évidence (ring primary)", async ({ page }) => {
+    await page.goto("/kiosk")
+    // Au moins un slot a la classe ring-2 ring-primary (prochain repas)
+    const nextSlot = page.locator(".ring-2.ring-primary")
+    // Peut ne pas exister si aucun repas n'est planifié dans la fenêtre
+    // On vérifie juste que la page charge sans erreur
+    await expect(page.locator("header")).toBeVisible()
+  })
+
+  test("ouvre la modal de détail au clic sur une recette", async ({ page }) => {
+    await page.goto("/kiosk")
+    await page.getByText("Pizza maison").first().click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+    await expect(page.getByRole("dialog").getByText("Pizza maison")).toBeVisible()
+  })
+
+  test("affiche les repas simples avec leur emoji si pas d'image", async ({ page }) => {
+    // Mock un repas simple (tag "simple", pas d'image, extras.emoji)
+    const simpleRecipeMeal = {
+      items: [
+        {
+          id: 10,
+          date: new Date().toISOString().slice(0, 10),
+          entryType: "lunch",
+          title: null,
+          recipeId: "simple-001",
+          recipe: {
+            id: "simple-001",
+            slug: "tomates-oeufs",
+            name: "tomates, oeufs",
+            description: "",
+            image: null,
+            tags: [{ id: "tag-simple", name: "simple", slug: "simple" }],
+            extras: { emoji: "🍳" },
+          },
+        },
+      ],
+      page: 1, per_page: -1, total: 1, total_pages: 1,
+    }
+
+    await page.route("**/api/households/mealplans**", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({ json: simpleRecipeMeal })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.goto("/kiosk")
+    await expect(page.getByText("tomates, oeufs")).toBeVisible()
+    // L'emoji doit apparaître dans le fallback image
+    await expect(page.getByText("🍳")).toBeVisible()
+  })
+})

--- a/e2e/simple-recipe.spec.ts
+++ b/e2e/simple-recipe.spec.ts
@@ -121,6 +121,8 @@ test.describe("Repas simple", () => {
         await route.fulfill({
           json: { id: 99, date: "2026-04-29", entryType: "dinner", recipeId: "simple-001", recipe: SIMPLE_RECIPE_CREATED },
         })
+      } else if (route.request().method() === "GET") {
+        await route.fulfill({ json: { items: [], page: 1, per_page: -1, total: 0, total_pages: 1 } })
       } else {
         await route.continue()
       }

--- a/e2e/simple-recipe.spec.ts
+++ b/e2e/simple-recipe.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "@playwright/test"
+import { setAuthToken, mockAllApiRoutes } from "./helpers/mockApi.ts"
+import { RECIPE_PIZZA, TAGS_RESPONSE } from "./fixtures/mealie.ts"
+
+const SIMPLE_RECIPE_CREATED = {
+  id: "simple-001",
+  slug: "tomates-farine",
+  name: "tomates, farine",
+  description: "",
+  recipeIngredient: [
+    { referenceId: "ri-s1", quantity: 1, unit: null, food: { id: "f4", name: "tomates" }, note: "", display: "1 tomates" },
+    { referenceId: "ri-s2", quantity: 1, unit: null, food: { id: "f1", name: "farine" }, note: "", display: "1 farine" },
+  ],
+  recipeInstructions: [],
+  tags: [{ id: "tag-simple", name: "simple", slug: "simple" }],
+  recipeCategory: [],
+  extras: { emoji: "🍅" },
+  image: null,
+}
+
+test.describe("Repas simple", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    await setAuthToken(page)
+    await mockAllApiRoutes(page)
+
+    // Mock création repas simple (POST /api/recipes → slug, puis GET slug, puis PATCH)
+    await page.route("**/api/recipes", async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify("tomates-farine") })
+      } else {
+        await route.continue()
+      }
+    })
+    await page.route("**/api/recipes/tomates-farine", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({ json: SIMPLE_RECIPE_CREATED })
+      } else if (route.request().method() === "PATCH") {
+        await route.fulfill({ json: SIMPLE_RECIPE_CREATED })
+      } else {
+        await route.continue()
+      }
+    })
+    // Tags : inclut le tag "simple"
+    await page.route("**/api/organizers/tags**", async (route) => {
+      await route.fulfill({
+        json: {
+          ...TAGS_RESPONSE,
+          items: [...TAGS_RESPONSE.items, { id: "tag-simple", name: "simple", slug: "simple" }],
+        },
+      })
+    })
+  })
+
+  test("ouvre le dialog repas simple depuis le planning", async ({ page }) => {
+    await page.goto("/planning")
+    await page.getByRole("button", { name: /ajouter/i }).first().click()
+    await expect(page.getByRole("dialog")).toBeVisible()
+    await page.getByRole("tab", { name: /repas simple/i }).click()
+    await expect(page.getByText(/ingrédients/i)).toBeVisible()
+  })
+
+  test("affiche les champs dans le bon ordre : ingrédients → nom → emoji", async ({ page }) => {
+    await page.goto("/planning")
+    await page.getByRole("button", { name: /ajouter/i }).first().click()
+    await page.getByRole("tab", { name: /repas simple/i }).click()
+
+    const labels = page.locator("label")
+    const texts = await labels.allInnerTexts()
+    const ingredientsIdx = texts.findIndex((t) => /ingrédients/i.test(t))
+    const nomIdx = texts.findIndex((t) => /nom du repas/i.test(t))
+    const emojiIdx = texts.findIndex((t) => /emoji/i.test(t))
+
+    expect(ingredientsIdx).toBeLessThan(nomIdx)
+    expect(nomIdx).toBeLessThan(emojiIdx)
+  })
+
+  test("pas de champ quantité ni unité dans le formulaire repas simple", async ({ page }) => {
+    await page.goto("/planning")
+    await page.getByRole("button", { name: /ajouter/i }).first().click()
+    await page.getByRole("tab", { name: /repas simple/i }).click()
+
+    await expect(page.getByPlaceholder(/qté/i)).not.toBeVisible()
+    await expect(page.getByPlaceholder(/unité/i)).not.toBeVisible()
+  })
+
+  test("le nom se génère automatiquement depuis les ingrédients", async ({ page }) => {
+    await page.goto("/planning")
+    await page.getByRole("button", { name: /ajouter/i }).first().click()
+    await page.getByRole("tab", { name: /repas simple/i }).click()
+
+    const input = page.getByPlaceholder(/aliment/i).first()
+    await input.fill("tomates")
+    await expect(page.getByPlaceholder(/généré automatiquement/i)).toHaveValue(/tomates/i)
+  })
+
+  test("affiche une grille d'emojis prédéfinis", async ({ page }) => {
+    await page.goto("/planning")
+    await page.getByRole("button", { name: /ajouter/i }).first().click()
+    await page.getByRole("tab", { name: /repas simple/i }).click()
+
+    // Au moins 5 boutons emoji visibles dans la section emoji
+    const emojiSection = page.locator("label", { hasText: /emoji/i }).locator("..")
+    const emojiButtons = emojiSection.locator("button")
+    await expect(emojiButtons).toHaveCount(await emojiButtons.count())
+    expect(await emojiButtons.count()).toBeGreaterThanOrEqual(5)
+  })
+
+  test("bouton Créer désactivé si aucun ingrédient renseigné", async ({ page }) => {
+    await page.goto("/planning")
+    await page.getByRole("button", { name: /ajouter/i }).first().click()
+    await page.getByRole("tab", { name: /repas simple/i }).click()
+
+    await expect(page.getByRole("button", { name: /créer et ajouter/i })).toBeDisabled()
+  })
+
+  test("crée un repas simple et l'ajoute au planning", async ({ page }) => {
+    let mealplanPostCalled = false
+    await page.route("**/api/households/mealplans**", async (route) => {
+      if (route.request().method() === "POST") {
+        mealplanPostCalled = true
+        await route.fulfill({ json: { id: 99, date: "2026-04-29", entryType: "dinner", recipeId: "simple-001", recipe: SIMPLE_RECIPE_CREATED } })
+      } else {
+        await route.continue()
+      }
+    })
+
+    await page.goto("/planning")
+    await page.getByRole("button", { name: /ajouter/i }).first().click()
+    await page.getByRole("tab", { name: /repas simple/i }).click()
+
+    const input = page.getByPlaceholder(/aliment/i).first()
+    await input.fill("tomates")
+
+    await page.getByRole("button", { name: /créer et ajouter/i }).click()
+    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 5000 })
+    expect(mealplanPostCalled).toBe(true)
+  })
+})

--- a/e2e/simple-recipe.spec.ts
+++ b/e2e/simple-recipe.spec.ts
@@ -41,7 +41,7 @@ test.describe("Repas simple", () => {
     await page.route("**/api/recipes/tomates-farine", async (route) => {
       if (route.request().method() === "GET") {
         await route.fulfill({ json: SIMPLE_RECIPE_CREATED })
-      } else if (route.request().method() === "PATCH") {
+      } else if (route.request().method() === "PUT" || route.request().method() === "PATCH") {
         await route.fulfill({ json: SIMPLE_RECIPE_CREATED })
       } else {
         await route.continue()

--- a/e2e/simple-recipe.spec.ts
+++ b/e2e/simple-recipe.spec.ts
@@ -9,12 +9,11 @@ const SIMPLE_RECIPE_CREATED = {
   description: "",
   recipeIngredient: [
     { referenceId: "ri-s1", quantity: 1, unit: null, food: { id: "f4", name: "tomates" }, note: "", display: "1 tomates" },
-    { referenceId: "ri-s2", quantity: 1, unit: null, food: { id: "f1", name: "farine" }, note: "", display: "1 farine" },
   ],
   recipeInstructions: [],
   tags: [{ id: "tag-simple", name: "simple", slug: "simple" }],
   recipeCategory: [],
-  extras: { emoji: "🍅" },
+  extras: { bonap_emoji: "🍅" },
   image: null,
 }
 
@@ -24,7 +23,6 @@ test.describe("Repas simple", () => {
     await setAuthToken(page)
     await mockAllApiRoutes(page)
 
-    // Mock création repas simple (POST /api/recipes → slug, puis GET slug, puis PATCH)
     await page.route("**/api/recipes", async (route) => {
       if (route.request().method() === "POST") {
         await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify("tomates-farine") })
@@ -41,7 +39,6 @@ test.describe("Repas simple", () => {
         await route.continue()
       }
     })
-    // Tags : inclut le tag "simple"
     await page.route("**/api/organizers/tags**", async (route) => {
       await route.fulfill({
         json: {
@@ -54,31 +51,34 @@ test.describe("Repas simple", () => {
 
   test("ouvre le dialog repas simple depuis le planning", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByRole("button", { name: /ajouter/i }).first().click()
+    await page.getByLabel("Ajouter un repas").first().click()
     await expect(page.getByRole("dialog")).toBeVisible()
-    await page.getByRole("tab", { name: /repas simple/i }).click()
+    await page.getByRole("button", { name: /repas simple/i }).click()
     await expect(page.getByText(/ingrédients/i)).toBeVisible()
   })
 
   test("affiche les champs dans le bon ordre : ingrédients → nom → emoji", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByRole("button", { name: /ajouter/i }).first().click()
-    await page.getByRole("tab", { name: /repas simple/i }).click()
+    await page.getByLabel("Ajouter un repas").first().click()
+    await page.getByRole("button", { name: /repas simple/i }).click()
 
     const labels = page.locator("label")
     const texts = await labels.allInnerTexts()
     const ingredientsIdx = texts.findIndex((t) => /ingrédients/i.test(t))
     const nomIdx = texts.findIndex((t) => /nom du repas/i.test(t))
-    const emojiIdx = texts.findIndex((t) => /emoji/i.test(t))
+    const emojiIdx = texts.findIndex((t) => /^emoji$/i.test(t.trim()))
 
+    expect(ingredientsIdx).toBeGreaterThanOrEqual(0)
+    expect(nomIdx).toBeGreaterThanOrEqual(0)
+    expect(emojiIdx).toBeGreaterThanOrEqual(0)
     expect(ingredientsIdx).toBeLessThan(nomIdx)
     expect(nomIdx).toBeLessThan(emojiIdx)
   })
 
   test("pas de champ quantité ni unité dans le formulaire repas simple", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByRole("button", { name: /ajouter/i }).first().click()
-    await page.getByRole("tab", { name: /repas simple/i }).click()
+    await page.getByLabel("Ajouter un repas").first().click()
+    await page.getByRole("button", { name: /repas simple/i }).click()
 
     await expect(page.getByPlaceholder(/qté/i)).not.toBeVisible()
     await expect(page.getByPlaceholder(/unité/i)).not.toBeVisible()
@@ -86,8 +86,8 @@ test.describe("Repas simple", () => {
 
   test("le nom se génère automatiquement depuis les ingrédients", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByRole("button", { name: /ajouter/i }).first().click()
-    await page.getByRole("tab", { name: /repas simple/i }).click()
+    await page.getByLabel("Ajouter un repas").first().click()
+    await page.getByRole("button", { name: /repas simple/i }).click()
 
     const input = page.getByPlaceholder(/aliment/i).first()
     await input.fill("tomates")
@@ -96,20 +96,22 @@ test.describe("Repas simple", () => {
 
   test("affiche une grille d'emojis prédéfinis", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByRole("button", { name: /ajouter/i }).first().click()
-    await page.getByRole("tab", { name: /repas simple/i }).click()
+    await page.getByLabel("Ajouter un repas").first().click()
+    await page.getByRole("button", { name: /repas simple/i }).click()
 
-    // Au moins 5 boutons emoji visibles dans la section emoji
-    const emojiSection = page.locator("label", { hasText: /emoji/i }).locator("..")
+    // La section emoji contient plusieurs boutons emoji (au moins 5)
+    const emojiLabel = page.locator("label", { hasText: /^emoji$/i })
+    await expect(emojiLabel).toBeVisible()
+    // Les boutons emoji sont des frères dans le parent de la label
+    const emojiSection = emojiLabel.locator("xpath=..")
     const emojiButtons = emojiSection.locator("button")
-    await expect(emojiButtons).toHaveCount(await emojiButtons.count())
     expect(await emojiButtons.count()).toBeGreaterThanOrEqual(5)
   })
 
   test("bouton Créer désactivé si aucun ingrédient renseigné", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByRole("button", { name: /ajouter/i }).first().click()
-    await page.getByRole("tab", { name: /repas simple/i }).click()
+    await page.getByLabel("Ajouter un repas").first().click()
+    await page.getByRole("button", { name: /repas simple/i }).click()
 
     await expect(page.getByRole("button", { name: /créer et ajouter/i })).toBeDisabled()
   })
@@ -119,19 +121,19 @@ test.describe("Repas simple", () => {
     await page.route("**/api/households/mealplans**", async (route) => {
       if (route.request().method() === "POST") {
         mealplanPostCalled = true
-        await route.fulfill({ json: { id: 99, date: "2026-04-29", entryType: "dinner", recipeId: "simple-001", recipe: SIMPLE_RECIPE_CREATED } })
+        await route.fulfill({
+          json: { id: 99, date: "2026-04-29", entryType: "dinner", recipeId: "simple-001", recipe: SIMPLE_RECIPE_CREATED },
+        })
       } else {
         await route.continue()
       }
     })
 
     await page.goto("/planning")
-    await page.getByRole("button", { name: /ajouter/i }).first().click()
-    await page.getByRole("tab", { name: /repas simple/i }).click()
+    await page.getByLabel("Ajouter un repas").first().click()
+    await page.getByRole("button", { name: /repas simple/i }).click()
 
-    const input = page.getByPlaceholder(/aliment/i).first()
-    await input.fill("tomates")
-
+    await page.getByPlaceholder(/aliment/i).first().fill("tomates")
     await page.getByRole("button", { name: /créer et ajouter/i }).click()
     await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 5000 })
     expect(mealplanPostCalled).toBe(true)

--- a/e2e/simple-recipe.spec.ts
+++ b/e2e/simple-recipe.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test"
 import { setAuthToken, mockAllApiRoutes } from "./helpers/mockApi.ts"
-import { RECIPE_PIZZA, TAGS_RESPONSE } from "./fixtures/mealie.ts"
+import { TAGS_RESPONSE } from "./fixtures/mealie.ts"
 
 const SIMPLE_RECIPE_CREATED = {
   id: "simple-001",
@@ -15,6 +15,14 @@ const SIMPLE_RECIPE_CREATED = {
   recipeCategory: [],
   extras: { bonap_emoji: "🍅" },
   image: null,
+}
+
+async function openSimpleTab(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  // Attendre que le planning soit chargé (table desktop ou boutons mobile)
+  await expect(page.getByRole("button", { name: "Ajouter un repas" }).first()).toBeVisible({ timeout: 8000 })
+  await page.getByRole("button", { name: "Ajouter un repas" }).first().click()
+  await expect(page.getByRole("dialog")).toBeVisible()
+  await page.getByRole("button", { name: /repas simple/i }).click()
 }
 
 test.describe("Repas simple", () => {
@@ -51,16 +59,13 @@ test.describe("Repas simple", () => {
 
   test("ouvre le dialog repas simple depuis le planning", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByLabel("Ajouter un repas").first().click()
-    await expect(page.getByRole("dialog")).toBeVisible()
-    await page.getByRole("button", { name: /repas simple/i }).click()
+    await openSimpleTab(page)
     await expect(page.getByText(/ingrédients/i)).toBeVisible()
   })
 
   test("affiche les champs dans le bon ordre : ingrédients → nom → emoji", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByLabel("Ajouter un repas").first().click()
-    await page.getByRole("button", { name: /repas simple/i }).click()
+    await openSimpleTab(page)
 
     const labels = page.locator("label")
     const texts = await labels.allInnerTexts()
@@ -77,8 +82,7 @@ test.describe("Repas simple", () => {
 
   test("pas de champ quantité ni unité dans le formulaire repas simple", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByLabel("Ajouter un repas").first().click()
-    await page.getByRole("button", { name: /repas simple/i }).click()
+    await openSimpleTab(page)
 
     await expect(page.getByPlaceholder(/qté/i)).not.toBeVisible()
     await expect(page.getByPlaceholder(/unité/i)).not.toBeVisible()
@@ -86,32 +90,25 @@ test.describe("Repas simple", () => {
 
   test("le nom se génère automatiquement depuis les ingrédients", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByLabel("Ajouter un repas").first().click()
-    await page.getByRole("button", { name: /repas simple/i }).click()
+    await openSimpleTab(page)
 
-    const input = page.getByPlaceholder(/aliment/i).first()
-    await input.fill("tomates")
+    await page.getByPlaceholder(/aliment/i).first().fill("tomates")
     await expect(page.getByPlaceholder(/généré automatiquement/i)).toHaveValue(/tomates/i)
   })
 
   test("affiche une grille d'emojis prédéfinis", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByLabel("Ajouter un repas").first().click()
-    await page.getByRole("button", { name: /repas simple/i }).click()
+    await openSimpleTab(page)
 
-    // La section emoji contient plusieurs boutons emoji (au moins 5)
     const emojiLabel = page.locator("label", { hasText: /^emoji$/i })
     await expect(emojiLabel).toBeVisible()
-    // Les boutons emoji sont des frères dans le parent de la label
     const emojiSection = emojiLabel.locator("xpath=..")
-    const emojiButtons = emojiSection.locator("button")
-    expect(await emojiButtons.count()).toBeGreaterThanOrEqual(5)
+    expect(await emojiSection.locator("button").count()).toBeGreaterThanOrEqual(5)
   })
 
   test("bouton Créer désactivé si aucun ingrédient renseigné", async ({ page }) => {
     await page.goto("/planning")
-    await page.getByLabel("Ajouter un repas").first().click()
-    await page.getByRole("button", { name: /repas simple/i }).click()
+    await openSimpleTab(page)
 
     await expect(page.getByRole("button", { name: /créer et ajouter/i })).toBeDisabled()
   })
@@ -130,8 +127,7 @@ test.describe("Repas simple", () => {
     })
 
     await page.goto("/planning")
-    await page.getByLabel("Ajouter un repas").first().click()
-    await page.getByRole("button", { name: /repas simple/i }).click()
+    await openSimpleTab(page)
 
     await page.getByPlaceholder(/aliment/i).first().fill("tomates")
     await page.getByRole("button", { name: /créer et ajouter/i }).click()

--- a/src/domain/recipe/repositories/IRecipeRepository.ts
+++ b/src/domain/recipe/repositories/IRecipeRepository.ts
@@ -31,5 +31,6 @@ export interface IRecipeRepository {
   getFavorites(): Promise<MealieFavoritesResponse>
   toggleFavorite(slug: string, isFavorite: boolean): Promise<void>
   uploadImage(slug: string, file: File): Promise<void>
+  deleteImage(slug: string): Promise<void>
   delete(slug: string): Promise<void>
 }

--- a/src/infrastructure/mealie/repositories/RecipeRepository.ts
+++ b/src/infrastructure/mealie/repositories/RecipeRepository.ts
@@ -211,6 +211,10 @@ export class RecipeRepository implements IRecipeRepository {
     return mealieApiClient.uploadImage(slug, file)
   }
 
+  async deleteImage(slug: string): Promise<void> {
+    return mealieApiClient.delete(`/api/recipes/${slug}/image`)
+  }
+
   private simplifyRecipeForPut(current: MealieRecipe): Partial<MealieRecipe> {
     return {
       ...current,

--- a/src/infrastructure/mealie/repositories/RecipeRepository.ts
+++ b/src/infrastructure/mealie/repositories/RecipeRepository.ts
@@ -202,6 +202,7 @@ export class RecipeRepository implements IRecipeRepository {
           text: step.text,
         })),
       tags: [...data.tags, ...seasonTags],
+      extras: { ...(current.extras ?? {}), ...(data.extras ?? {}) },
     }
     return mealieApiClient.put<MealieRecipe>(`/api/recipes/${slug}`, payload)
   }

--- a/src/infrastructure/recipe/RecipeEmojiStore.ts
+++ b/src/infrastructure/recipe/RecipeEmojiStore.ts
@@ -1,0 +1,25 @@
+const KEY = "bonap:recipe_emojis"
+
+function load(): Record<string, string> {
+  try {
+    return JSON.parse(localStorage.getItem(KEY) ?? "{}") as Record<string, string>
+  } catch {
+    return {}
+  }
+}
+
+export const recipeEmojiStore = {
+  set(recipeId: string, emoji: string): void {
+    const store = load()
+    store[recipeId] = emoji
+    localStorage.setItem(KEY, JSON.stringify(store))
+  },
+  remove(recipeId: string): void {
+    const store = load()
+    delete store[recipeId]
+    localStorage.setItem(KEY, JSON.stringify(store))
+  },
+  get(recipeId: string): string | null {
+    return load()[recipeId] ?? null
+  },
+}

--- a/src/presentation/components/RecipeCard.tsx
+++ b/src/presentation/components/RecipeCard.tsx
@@ -15,8 +15,10 @@ interface RecipeCardProps {
 
 export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
   const [imgError, setImgError] = useState(false)
+  const hasImage = Boolean(recipe.image)
   const imageUrl = recipeImageUrl(recipe, "min-original")
   const emoji = getRecipeEmoji(recipe)
+  const showEmoji = !hasImage || imgError
   const seasons = getRecipeSeasonsFromTags(recipe.tags)
   const categories = recipe.recipeCategory ?? []
 
@@ -37,7 +39,7 @@ export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
       >
         {/* Image carrée */}
         <div className="relative aspect-square w-full overflow-hidden bg-muted">
-          {!imgError ? (
+          {!showEmoji ? (
             <img
               src={imageUrl}
               alt={recipe.name}
@@ -45,7 +47,7 @@ export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
               className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center">
+            <div className="flex h-full w-full items-center justify-center bg-muted">
               <span className="text-4xl">{emoji ?? "🍽️"}</span>
             </div>
           )}

--- a/src/presentation/components/RecipeCard.tsx
+++ b/src/presentation/components/RecipeCard.tsx
@@ -5,6 +5,7 @@ import type { MealieRecipe } from "../../shared/types/mealie.ts"
 import { getRecipeSeasonsFromTags } from "../../shared/utils/season.ts"
 import { cn } from "../../lib/utils.ts"
 import { recipeImageUrl } from "../../shared/utils/image.ts"
+import { getRecipeEmoji } from "../../shared/utils/recipeEmoji.ts"
 
 interface RecipeCardProps {
   recipe: MealieRecipe
@@ -15,6 +16,7 @@ interface RecipeCardProps {
 export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
   const [imgError, setImgError] = useState(false)
   const imageUrl = recipeImageUrl(recipe, "min-original")
+  const emoji = getRecipeEmoji(recipe)
   const seasons = getRecipeSeasonsFromTags(recipe.tags)
   const categories = recipe.recipeCategory ?? []
 
@@ -44,7 +46,7 @@ export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center">
-              <span className="text-4xl opacity-20">🍽️</span>
+              <span className="text-4xl">{emoji ?? "🍽️"}</span>
             </div>
           )}
 

--- a/src/presentation/components/RecipeCard.tsx
+++ b/src/presentation/components/RecipeCard.tsx
@@ -46,7 +46,7 @@ export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center">
-              <span className="text-4xl">{emoji ?? "🍽️"}</span>
+              {emoji && <span className="text-4xl">{emoji}</span>}
             </div>
           )}
 

--- a/src/presentation/components/RecipeCard.tsx
+++ b/src/presentation/components/RecipeCard.tsx
@@ -15,10 +15,8 @@ interface RecipeCardProps {
 
 export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
   const [imgError, setImgError] = useState(false)
-  const hasImage = Boolean(recipe.image)
   const imageUrl = recipeImageUrl(recipe, "min-original")
   const emoji = getRecipeEmoji(recipe)
-  const showEmoji = !hasImage || imgError
   const seasons = getRecipeSeasonsFromTags(recipe.tags)
   const categories = recipe.recipeCategory ?? []
 
@@ -39,7 +37,7 @@ export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
       >
         {/* Image carrée */}
         <div className="relative aspect-square w-full overflow-hidden bg-muted">
-          {!showEmoji ? (
+          {!imgError ? (
             <img
               src={imageUrl}
               alt={recipe.name}
@@ -47,7 +45,7 @@ export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
               className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.04]"
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center bg-muted">
+            <div className="flex h-full w-full items-center justify-center">
               <span className="text-4xl">{emoji ?? "🍽️"}</span>
             </div>
           )}

--- a/src/presentation/components/RecipeCard.tsx
+++ b/src/presentation/components/RecipeCard.tsx
@@ -1,11 +1,13 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Link } from "react-router-dom"
 import { SeasonBadge } from "./SeasonBadge.tsx"
 import type { MealieRecipe } from "../../shared/types/mealie.ts"
 import { getRecipeSeasonsFromTags } from "../../shared/utils/season.ts"
 import { cn } from "../../lib/utils.ts"
 import { recipeImageUrl } from "../../shared/utils/image.ts"
-import { getRecipeEmoji } from "../../shared/utils/recipeEmoji.ts"
+import { getRecipeEmoji, EXTRAS_EMOJI_KEY } from "../../shared/utils/recipeEmoji.ts"
+import { recipeEmojiStore } from "../../infrastructure/recipe/RecipeEmojiStore.ts"
+import { getRecipeUseCase } from "../../infrastructure/container.ts"
 
 interface RecipeCardProps {
   recipe: MealieRecipe
@@ -15,8 +17,23 @@ interface RecipeCardProps {
 
 export function RecipeCard({ recipe, onSelect, selected }: RecipeCardProps) {
   const [imgError, setImgError] = useState(false)
+  const [emoji, setEmoji] = useState<string | null>(() => getRecipeEmoji(recipe))
   const imageUrl = recipeImageUrl(recipe, "min-original")
-  const emoji = getRecipeEmoji(recipe)
+
+  // When image fails and no emoji cached yet, fetch full recipe to get extras
+  useEffect(() => {
+    if (!imgError || emoji !== null) return
+    let cancelled = false
+    getRecipeUseCase.execute(recipe.slug).then((full) => {
+      if (cancelled) return
+      const e = full.extras?.[EXTRAS_EMOJI_KEY] ?? null
+      if (e) {
+        recipeEmojiStore.set(full.id, e)
+        setEmoji(e)
+      }
+    }).catch(() => {/* ignore */})
+    return () => { cancelled = true }
+  }, [imgError, emoji, recipe.slug])
   const seasons = getRecipeSeasonsFromTags(recipe.tags)
   const categories = recipe.recipeCategory ?? []
 

--- a/src/presentation/components/RecipeDrawer.tsx
+++ b/src/presentation/components/RecipeDrawer.tsx
@@ -263,7 +263,7 @@ export function RecipeDrawer({ slug, allCategories, closing, onClose }: RecipeDr
                                                     "transition-all duration-150",
                                                 )}
                                             >
-                                                <CookingPot className="h-3.5 w-3.5" />
+                                                <ExternalLink className="h-3.5 w-3.5" />
                                                 <span className="sm:hidden">Page complète</span>
                                             </Link>
                                         </TooltipTrigger>

--- a/src/presentation/components/RecipeDrawer.tsx
+++ b/src/presentation/components/RecipeDrawer.tsx
@@ -4,7 +4,7 @@ import { CookingMode } from "./CookingMode"
 import { PlanningSlotPicker } from "./PlanningSlotPicker"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip"
 import { Badge } from "./ui/badge"
-import { X, CalendarPlus, UtensilsCrossed, ExternalLink, CookingPot, Loader2, Clock, Star, Heart } from "lucide-react"
+import { X, CalendarPlus, UtensilsCrossed, ExternalLink, Loader2, Clock, Star, Heart } from "lucide-react"
 
 import { useRecipe } from "../hooks/useRecipe"
 import { useUpdateSeasons } from "../hooks/useUpdateSeasons"

--- a/src/presentation/components/RecipeDrawer.tsx
+++ b/src/presentation/components/RecipeDrawer.tsx
@@ -14,6 +14,7 @@ import { useUpdateCalorieTag } from "../../presentation/hooks/useUpdateCalorieTa
 
 import { getRecipeSeasonsFromTags } from "../../shared/utils/season"
 import { recipeImageUrl } from "../../shared/utils/image"
+import { getRecipeEmoji } from "../../shared/utils/recipeEmoji"
 import { formatDuration } from "../../shared/utils/duration"
 import { useUpdateRating } from "../../presentation/hooks/useUpdateRating"
 
@@ -22,7 +23,7 @@ import { cn } from "../../lib/utils"
 import { RecipeIngredientsList } from "./RecipeIngredientsList"
 import { RecipeInstructionsList } from "./RecipeInstructionsList"
 
-import type { MealieCategory, MealieRatings, Season } from "../../shared/types/mealie"
+import type { MealieCategory, MealieRatings, MealieRecipe, Season } from "../../shared/types/mealie"
 import { SEASONS, SEASON_LABELS } from "../../shared/types/mealie"
 
 import { addMealUseCase, deleteMealUseCase } from "../../infrastructure/container"
@@ -323,15 +324,7 @@ export function RecipeDrawer({ slug, allCategories, closing, onClose }: RecipeDr
                     {recipe && (
                         <article className="space-y-5 pb-24">
                             {/* Image */}
-                            <div className="relative">
-                                <img
-                                    src={recipeImageUrl(recipe, "original")}
-                                    alt={recipe.name}
-                                    className="aspect-video w-full object-cover"
-                                />
-                                {/* Dégradé bas pour transition vers le contenu */}
-                                <div className="absolute bottom-0 inset-x-0 h-12 bg-gradient-to-t from-card to-transparent" />
-                            </div>
+                            <RecipeDrawerImage recipe={recipe} />
 
                             <div className="space-y-4 px-5">
                                 {/* Nom */}
@@ -526,5 +519,32 @@ export function RecipeDrawer({ slug, allCategories, closing, onClose }: RecipeDr
                 </div>
             </div>
         </>
+    )
+}
+
+function RecipeDrawerImage({ recipe }: { recipe: MealieRecipe }) {
+    const [imgError, setImgError] = useState(false)
+    const hasImage = Boolean(recipe.image)
+    const emoji = getRecipeEmoji(recipe)
+    const showEmoji = !hasImage || imgError
+
+    return (
+        <div className="relative">
+            {!showEmoji ? (
+                <>
+                    <img
+                        src={recipeImageUrl(recipe, "original")}
+                        alt={recipe.name}
+                        className="aspect-video w-full object-cover"
+                        onError={() => setImgError(true)}
+                    />
+                    <div className="absolute bottom-0 inset-x-0 h-12 bg-gradient-to-t from-card to-transparent" />
+                </>
+            ) : (
+                <div className="flex aspect-video w-full items-center justify-center bg-muted">
+                    <span className="text-6xl">{emoji ?? "🍽️"}</span>
+                </div>
+            )}
+        </div>
     )
 }

--- a/src/presentation/components/RecipeDrawer.tsx
+++ b/src/presentation/components/RecipeDrawer.tsx
@@ -524,13 +524,11 @@ export function RecipeDrawer({ slug, allCategories, closing, onClose }: RecipeDr
 
 function RecipeDrawerImage({ recipe }: { recipe: MealieRecipe }) {
     const [imgError, setImgError] = useState(false)
-    const hasImage = Boolean(recipe.image)
     const emoji = getRecipeEmoji(recipe)
-    const showEmoji = !hasImage || imgError
 
     return (
         <div className="relative">
-            {!showEmoji ? (
+            {!imgError ? (
                 <>
                     <img
                         src={recipeImageUrl(recipe, "original")}

--- a/src/presentation/components/RecipeDrawer.tsx
+++ b/src/presentation/components/RecipeDrawer.tsx
@@ -540,7 +540,7 @@ function RecipeDrawerImage({ recipe }: { recipe: MealieRecipe }) {
                 </>
             ) : (
                 <div className="flex aspect-video w-full items-center justify-center bg-muted">
-                    <span className="text-6xl">{emoji ?? "🍽️"}</span>
+                    {emoji && <span className="text-6xl">{emoji}</span>}
                 </div>
             )}
         </div>

--- a/src/presentation/components/RecipeFormDialog.tsx
+++ b/src/presentation/components/RecipeFormDialog.tsx
@@ -19,6 +19,7 @@ import { useTags } from "../hooks/useTags.ts"
 import { useFoods } from "../hooks/useFoods.ts"
 import { useUnits } from "../hooks/useUnits.ts"
 import type { MealieRecipe, RecipeFormData, RecipeFormIngredient, RecipeFormInstruction, Season } from "../../shared/types/mealie.ts"
+import { cn } from "../../lib/utils.ts"
 import { SEASONS, SEASON_LABELS } from "../../shared/types/mealie.ts"
 import { getRecipeSeasonsFromTags, isSeasonTag } from "../../shared/utils/season.ts"
 

--- a/src/presentation/components/RecipeFormDialog.tsx
+++ b/src/presentation/components/RecipeFormDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
-import { Loader2, AlertCircle, Plus, Trash2, GripVertical } from "lucide-react"
+import { Loader2, AlertCircle, Plus, Trash2, GripVertical, Smile } from "lucide-react"
+import { FOOD_EMOJIS, EXTRAS_EMOJI_KEY } from "../../shared/utils/recipeEmoji.ts"
 import {
   Dialog,
   DialogContent,
@@ -98,6 +99,7 @@ function buildInitialFormData(recipe?: MealieRecipe): RecipeFormData {
     seasons: getRecipeSeasonsFromTags(recipe?.tags),
     categories: (recipe?.recipeCategory ?? []).map((c) => ({ id: c.id, name: c.name, slug: c.slug })),
     tags: (recipe?.tags ?? []).filter((t) => !isSeasonTag(t)).map((t) => ({ id: t.id, name: t.name, slug: t.slug })),
+    extras: recipe?.extras ? { ...recipe.extras } : {},
   }
 }
 
@@ -277,6 +279,52 @@ function RecipeFormContent({ recipe, onClose, onSuccess }: RecipeFormContentProp
               {Number(formData.recipeYield) === 1 ? "1 portion" : `${formData.recipeYield} portions`}
             </span>
           )}
+        </div>
+      </div>
+
+      {/* Emoji illustration */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Smile className="h-4 w-4 text-muted-foreground" />
+          <Label>Illustration (emoji)</Label>
+          <span className="text-xs text-muted-foreground">— affiché à la place de l'image si absente</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {/* "Aucun" option */}
+          <button
+            type="button"
+            onClick={() => {
+              const next = { ...(formData.extras ?? {}) }
+              delete next[EXTRAS_EMOJI_KEY]
+              setFormData((prev) => ({ ...prev, extras: next }))
+            }}
+            className={cn(
+              "h-9 px-3 rounded-md border text-xs font-medium transition-colors",
+              !formData.extras?.[EXTRAS_EMOJI_KEY]
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-border text-muted-foreground hover:bg-secondary",
+            )}
+          >
+            Aucun
+          </button>
+          {FOOD_EMOJIS.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              onClick={() => setFormData((prev) => ({
+                ...prev,
+                extras: { ...(prev.extras ?? {}), [EXTRAS_EMOJI_KEY]: emoji },
+              }))}
+              className={cn(
+                "h-9 w-9 rounded-md border text-xl transition-colors",
+                formData.extras?.[EXTRAS_EMOJI_KEY] === emoji
+                  ? "border-primary bg-primary/10"
+                  : "border-border hover:bg-secondary",
+              )}
+            >
+              {emoji}
+            </button>
+          ))}
         </div>
       </div>
 

--- a/src/presentation/components/RecipeImage.tsx
+++ b/src/presentation/components/RecipeImage.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react"
+import type { MealieRecipe } from "../../shared/types/mealie.ts"
+import { recipeImageUrl } from "../../shared/utils/image.ts"
+import { getRecipeEmoji, EXTRAS_EMOJI_KEY } from "../../shared/utils/recipeEmoji.ts"
+import { recipeEmojiStore } from "../../infrastructure/recipe/RecipeEmojiStore.ts"
+import { getRecipeUseCase } from "../../infrastructure/container.ts"
+import { cn } from "../../lib/utils.ts"
+
+interface RecipeImageProps {
+  recipe: Pick<MealieRecipe, "id" | "slug" | "extras">
+  alt?: string
+  className?: string
+  fallbackClassName?: string
+}
+
+export function RecipeImage({ recipe, alt = "", className, fallbackClassName }: RecipeImageProps) {
+  const [imgError, setImgError] = useState(false)
+  const [emoji, setEmoji] = useState<string | null>(() => getRecipeEmoji(recipe))
+  const imageUrl = recipeImageUrl(recipe, "min-original")
+
+  useEffect(() => {
+    if (!imgError || emoji !== null) return
+    let cancelled = false
+    getRecipeUseCase.execute(recipe.slug).then((full) => {
+      if (cancelled) return
+      const e = full.extras?.[EXTRAS_EMOJI_KEY] ?? null
+      if (e) {
+        recipeEmojiStore.set(full.id, e)
+        setEmoji(e)
+      }
+    }).catch(() => {})
+    return () => { cancelled = true }
+  }, [imgError, emoji, recipe.slug])
+
+  if (!imgError) {
+    return (
+      <img
+        src={imageUrl}
+        alt={alt}
+        className={className}
+        onError={() => setImgError(true)}
+      />
+    )
+  }
+
+  return (
+    <div className={cn("flex items-center justify-center bg-muted", fallbackClassName ?? className)}>
+      <span className="text-2xl">{emoji ?? "🍽️"}</span>
+    </div>
+  )
+}

--- a/src/presentation/components/RecipePickerDialog.tsx
+++ b/src/presentation/components/RecipePickerDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { Search, Loader2, UtensilsCrossed, X } from "lucide-react"
+import { Search, Loader2, UtensilsCrossed, X, ChefHat } from "lucide-react"
 import {
   Dialog,
   DialogContent,
@@ -11,10 +11,11 @@ import { Input } from "./ui/input.tsx"
 import { useRecipesInfinite } from "../hooks/useRecipesInfinite.ts"
 import type { MealieRecipe } from "../../shared/types/mealie.ts"
 import { recipeImageUrl } from "../../shared/utils/image.ts"
+import { getRecipeEmoji } from "../../shared/utils/recipeEmoji.ts"
+import { SimpleRecipePicker } from "./SimpleRecipePicker.tsx"
+import { cn } from "../../lib/utils.ts"
 
 // ─── Isolated list ────────────────────────────────────────────────────────────
-// Separate component: only re-renders when `search` (debounced) changes,
-// not on every keystroke.
 
 function RecipeList({
   search,
@@ -51,26 +52,22 @@ function RecipeList({
   return (
     <>
       <div className="grid grid-cols-5 gap-2 p-1">
-        {recipes.map((recipe) => (
-          <button
-            key={recipe.id}
-            type="button"
-            onClick={() => onSelect(recipe)}
-            className="group flex flex-col gap-1.5 rounded-[var(--radius-lg)] p-1.5 text-left transition-colors hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <div className="relative aspect-square w-full overflow-hidden rounded-[var(--radius-md)] bg-muted">
-              <img
-                src={recipeImageUrl(recipe, "min-original")}
-                alt={recipe.name}
-                className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-                loading="lazy"
-              />
-            </div>
-            <span className="line-clamp-2 w-full text-[11px] font-medium leading-tight">
-              {recipe.name}
-            </span>
-          </button>
-        ))}
+        {recipes.map((recipe) => {
+          const emoji = getRecipeEmoji(recipe)
+          return (
+            <button
+              key={recipe.id}
+              type="button"
+              onClick={() => onSelect(recipe)}
+              className="group flex flex-col gap-1.5 rounded-[var(--radius-lg)] p-1.5 text-left transition-colors hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <RecipeThumbnail recipe={recipe} emoji={emoji} />
+              <span className="line-clamp-2 w-full text-[11px] font-medium leading-tight">
+                {recipe.name}
+              </span>
+            </button>
+          )
+        })}
       </div>
 
       <div ref={sentinelRef} className="h-4" />
@@ -84,7 +81,30 @@ function RecipeList({
   )
 }
 
+function RecipeThumbnail({ recipe, emoji }: { recipe: MealieRecipe; emoji: string | null }) {
+  const [imgError, setImgError] = useState(false)
+  return (
+    <div className="relative aspect-square w-full overflow-hidden rounded-[var(--radius-md)] bg-muted">
+      {!imgError ? (
+        <img
+          src={recipeImageUrl(recipe, "min-original")}
+          alt={recipe.name}
+          className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+          loading="lazy"
+          onError={() => setImgError(true)}
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-2xl">
+          {emoji ?? "🍽️"}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ─── Dialog ───────────────────────────────────────────────────────────────────
+
+type Tab = "recipes" | "simple"
 
 interface RecipePickerDialogProps {
   open: boolean
@@ -97,10 +117,10 @@ export function RecipePickerDialog({
   onOpenChange,
   onSelect,
 }: RecipePickerDialogProps) {
+  const [tab, setTab] = useState<Tab>("recipes")
   const [inputValue, setInputValue] = useState("")
   const [debouncedSearch, setDebouncedSearch] = useState("")
 
-  // Debounce: update effective search 300ms after the last keystroke
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(inputValue), 300)
     return () => clearTimeout(timer)
@@ -110,6 +130,7 @@ export function RecipePickerDialog({
     if (!value) {
       setInputValue("")
       setDebouncedSearch("")
+      setTab("recipes")
     }
     onOpenChange(value)
   }
@@ -123,36 +144,81 @@ export function RecipePickerDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-3xl">
         <DialogHeader>
-          <DialogTitle>Choisir une recette</DialogTitle>
+          <DialogTitle>Choisir un repas</DialogTitle>
           <DialogDescription>
-            Recherchez et sélectionnez une recette pour ce repas.
+            Sélectionnez une recette existante ou créez un repas simple à la volée.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            placeholder="Rechercher une recette..."
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            className="pl-9 pr-9"
-            autoFocus
-          />
-          {inputValue && (
-            <button
-              type="button"
-              onClick={() => setInputValue("")}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          )}
+        {/* Tabs */}
+        <div className="flex gap-1 rounded-lg border border-border bg-secondary/50 p-1">
+          <TabButton active={tab === "recipes"} onClick={() => setTab("recipes")}>
+            <UtensilsCrossed className="h-3.5 w-3.5" />
+            Recettes
+          </TabButton>
+          <TabButton active={tab === "simple"} onClick={() => setTab("simple")}>
+            <ChefHat className="h-3.5 w-3.5" />
+            Repas simple
+          </TabButton>
         </div>
 
-        <div className="flex-1 overflow-y-auto">
-          <RecipeList search={debouncedSearch} onSelect={handleSelect} />
-        </div>
+        {tab === "recipes" ? (
+          <>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Rechercher une recette..."
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                className="pl-9 pr-9"
+                autoFocus
+              />
+              {inputValue && (
+                <button
+                  type="button"
+                  onClick={() => setInputValue("")}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="flex-1 overflow-y-auto">
+              <RecipeList search={debouncedSearch} onSelect={handleSelect} />
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 overflow-y-auto px-1">
+            <SimpleRecipePicker onCreated={handleSelect} />
+          </div>
+        )}
       </DialogContent>
     </Dialog>
+  )
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-colors",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
   )
 }

--- a/src/presentation/components/RecipePickerDialog.tsx
+++ b/src/presentation/components/RecipePickerDialog.tsx
@@ -83,9 +83,10 @@ function RecipeList({
 
 function RecipeThumbnail({ recipe, emoji }: { recipe: MealieRecipe; emoji: string | null }) {
   const [imgError, setImgError] = useState(false)
+  const showEmoji = !recipe.image || imgError
   return (
     <div className="relative aspect-square w-full overflow-hidden rounded-[var(--radius-md)] bg-muted">
-      {!imgError ? (
+      {!showEmoji ? (
         <img
           src={recipeImageUrl(recipe, "min-original")}
           alt={recipe.name}

--- a/src/presentation/components/RecipePickerDialog.tsx
+++ b/src/presentation/components/RecipePickerDialog.tsx
@@ -95,7 +95,7 @@ function RecipeThumbnail({ recipe, emoji }: { recipe: MealieRecipe; emoji: strin
         />
       ) : (
         <div className="flex h-full w-full items-center justify-center text-2xl">
-          {emoji ?? "🍽️"}
+          {emoji}
         </div>
       )}
     </div>

--- a/src/presentation/components/RecipePickerDialog.tsx
+++ b/src/presentation/components/RecipePickerDialog.tsx
@@ -83,10 +83,9 @@ function RecipeList({
 
 function RecipeThumbnail({ recipe, emoji }: { recipe: MealieRecipe; emoji: string | null }) {
   const [imgError, setImgError] = useState(false)
-  const showEmoji = !recipe.image || imgError
   return (
     <div className="relative aspect-square w-full overflow-hidden rounded-[var(--radius-md)] bg-muted">
-      {!showEmoji ? (
+      {!imgError ? (
         <img
           src={recipeImageUrl(recipe, "min-original")}
           alt={recipe.name}

--- a/src/presentation/components/RecipePickerDialog.tsx
+++ b/src/presentation/components/RecipePickerDialog.tsx
@@ -142,7 +142,17 @@ export function RecipePickerDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-3xl">
+      <DialogContent
+        className="flex max-h-[85vh] flex-col sm:max-w-3xl"
+        onPointerDownOutside={(e) => {
+          // Autocomplete dropdowns are portalled outside the dialog DOM.
+          // Prevent Radix from closing the dialog when the user clicks a suggestion.
+          const target = e.target as Element
+          if (target.closest('[role="listbox"]') || target.closest('[role="option"]')) {
+            e.preventDefault()
+          }
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Choisir un repas</DialogTitle>
           <DialogDescription>

--- a/src/presentation/components/RecipePickerDialog.tsx
+++ b/src/presentation/components/RecipePickerDialog.tsx
@@ -120,6 +120,7 @@ export function RecipePickerDialog({
   const [tab, setTab] = useState<Tab>("recipes")
   const [inputValue, setInputValue] = useState("")
   const [debouncedSearch, setDebouncedSearch] = useState("")
+  const [dialogContentEl, setDialogContentEl] = useState<HTMLDivElement | null>(null)
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(inputValue), 300)
@@ -143,10 +144,17 @@ export function RecipePickerDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
+        ref={setDialogContentEl}
         className="flex max-h-[85vh] flex-col sm:max-w-3xl"
         onPointerDownOutside={(e) => {
           // Autocomplete dropdowns are portalled outside the dialog DOM.
           // Prevent Radix from closing the dialog when the user clicks a suggestion.
+          const target = e.target as Element
+          if (target.closest('[role="listbox"]') || target.closest('[role="option"]')) {
+            e.preventDefault()
+          }
+        }}
+        onInteractOutside={(e) => {
           const target = e.target as Element
           if (target.closest('[role="listbox"]') || target.closest('[role="option"]')) {
             e.preventDefault()
@@ -200,7 +208,7 @@ export function RecipePickerDialog({
           </>
         ) : (
           <div className="flex-1 overflow-y-auto px-1">
-            <SimpleRecipePicker onCreated={handleSelect} />
+            <SimpleRecipePicker onCreated={handleSelect} dropdownContainer={dialogContentEl} />
           </div>
         )}
       </DialogContent>

--- a/src/presentation/components/SimpleRecipePicker.tsx
+++ b/src/presentation/components/SimpleRecipePicker.tsx
@@ -11,6 +11,7 @@ import { createRecipeUseCase } from "../../infrastructure/container.ts"
 import { mealieApiClient } from "../../infrastructure/mealie/api/index.ts"
 import type { MealieRecipe, RecipeFormIngredient } from "../../shared/types/mealie.ts"
 import { randomFoodEmoji, EXTRAS_EMOJI_KEY, SIMPLE_RECIPE_TAG_SLUG } from "../../shared/utils/recipeEmoji.ts"
+import { recipeEmojiStore } from "../../infrastructure/recipe/RecipeEmojiStore.ts"
 
 interface SimpleRecipePickerProps {
   onCreated: (recipe: MealieRecipe) => void
@@ -89,6 +90,7 @@ export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
         tags: [simpleTag],
         extras: { [EXTRAS_EMOJI_KEY]: randomFoodEmoji() },
       })
+      recipeEmojiStore.set(recipe.id, recipe.extras?.[EXTRAS_EMOJI_KEY] ?? "")
       onCreated(recipe)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Impossible de créer le repas simple.")

--- a/src/presentation/components/SimpleRecipePicker.tsx
+++ b/src/presentation/components/SimpleRecipePicker.tsx
@@ -5,38 +5,35 @@ import { Button } from "./ui/button.tsx"
 import { Label } from "./ui/label.tsx"
 import { Autocomplete } from "./ui/autocomplete.tsx"
 import { useFoods } from "../hooks/useFoods.ts"
-import { useUnits } from "../hooks/useUnits.ts"
 import { useTags } from "../hooks/useTags.ts"
 import { createRecipeUseCase } from "../../infrastructure/container.ts"
 import { mealieApiClient } from "../../infrastructure/mealie/api/index.ts"
 import type { MealieRecipe, RecipeFormIngredient } from "../../shared/types/mealie.ts"
-import { randomFoodEmoji, EXTRAS_EMOJI_KEY, SIMPLE_RECIPE_TAG_SLUG } from "../../shared/utils/recipeEmoji.ts"
+import { randomFoodEmoji, FOOD_EMOJIS, EXTRAS_EMOJI_KEY, SIMPLE_RECIPE_TAG_SLUG } from "../../shared/utils/recipeEmoji.ts"
 import { recipeEmojiStore } from "../../infrastructure/recipe/RecipeEmojiStore.ts"
+import { cn } from "../../lib/utils.ts"
 
 interface SimpleRecipePickerProps {
   onCreated: (recipe: MealieRecipe) => void
+  dropdownContainer?: HTMLElement | null
 }
 
 function buildEmptyIngredient(): RecipeFormIngredient {
   return { quantity: "1", unit: "", unitId: undefined, food: "", foodId: undefined, note: "" }
 }
 
-export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
+export function SimpleRecipePicker({ onCreated, dropdownContainer }: SimpleRecipePickerProps) {
   const { foods } = useFoods()
-  const { units } = useUnits()
   const { tags } = useTags()
 
   const [name, setName] = useState("")
   const [nameEditedManually, setNameEditedManually] = useState(false)
+  const [emoji, setEmoji] = useState(() => randomFoodEmoji())
   const [ingredients, setIngredients] = useState<RecipeFormIngredient[]>([buildEmptyIngredient()])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const foodOptions = foods.map((f) => ({ id: f.id, label: f.name }))
-  const unitOptions = units.map((u) => ({
-    id: u.id,
-    label: u.useAbbreviation && u.abbreviation ? u.abbreviation : u.name,
-  }))
 
   const updateIngredient = (index: number, patch: Partial<RecipeFormIngredient>) => {
     setIngredients((prev) => {
@@ -73,6 +70,7 @@ export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
 
   const handleCreate = async () => {
     const finalName = name.trim() || "Repas simple"
+    const finalEmoji = emoji.trim() || randomFoodEmoji()
     setLoading(true)
     setError(null)
     try {
@@ -88,7 +86,7 @@ export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
         seasons: [],
         categories: [],
         tags: [simpleTag],
-        extras: { [EXTRAS_EMOJI_KEY]: randomFoodEmoji() },
+        extras: { [EXTRAS_EMOJI_KEY]: finalEmoji },
       })
       recipeEmojiStore.set(recipe.id, recipe.extras?.[EXTRAS_EMOJI_KEY] ?? "")
       onCreated(recipe)
@@ -103,20 +101,7 @@ export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
 
   return (
     <div className="space-y-5">
-      <div className="space-y-1.5">
-        <Label htmlFor="simple-name">Nom du repas</Label>
-        <Input
-          id="simple-name"
-          placeholder="Généré automatiquement depuis les ingrédients"
-          value={name}
-          onChange={(e) => {
-            setName(e.target.value)
-            setNameEditedManually(true)
-          }}
-          disabled={loading}
-        />
-      </div>
-
+      {/* 1. Ingrédients */}
       <div className="space-y-3">
         <div className="flex items-center justify-between">
           <Label>Ingrédients</Label>
@@ -126,25 +111,9 @@ export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
           </Button>
         </div>
 
-        <div className="hidden sm:grid sm:grid-cols-[80px_1.5fr_1fr_32px] sm:gap-2 sm:items-center px-1">
-          <span className="text-xs text-muted-foreground font-medium">Qté</span>
-          <span className="text-xs text-muted-foreground font-medium">Aliment</span>
-          <span className="text-xs text-muted-foreground font-medium">Unité</span>
-          <span />
-        </div>
-
         <div className="space-y-2">
           {ingredients.map((ing, index) => (
-            <div key={index} className="grid grid-cols-[60px_1.5fr_1fr_32px] sm:grid-cols-[80px_1.5fr_1fr_32px] gap-2 items-center">
-              <Input
-                type="text"
-                inputMode="decimal"
-                placeholder="Qté"
-                value={ing.quantity}
-                onChange={(e) => updateIngredient(index, { quantity: e.target.value })}
-                disabled={loading}
-                className="min-w-0 px-2"
-              />
+            <div key={index} className="flex gap-2 items-center">
               <Autocomplete
                 value={ing.food}
                 onChange={(value, option) => updateIngredient(index, {
@@ -154,16 +123,8 @@ export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
                 options={foodOptions}
                 placeholder="Aliment…"
                 disabled={loading}
-              />
-              <Autocomplete
-                value={ing.unit}
-                onChange={(value, option) => updateIngredient(index, {
-                  unit: value,
-                  unitId: option ? option.id : undefined,
-                })}
-                options={unitOptions}
-                placeholder="Unité…"
-                disabled={loading}
+                className="flex-1"
+                portalContainer={dropdownContainer}
               />
               <Button
                 type="button"
@@ -179,8 +140,46 @@ export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
           ))}
         </div>
         <p className="text-xs text-muted-foreground">
-          Une recette avec le tag «&nbsp;simple&nbsp;» sera créée dans Mealie, avec un emoji attribué automatiquement.
+          Quantité par défaut : 1, sans unité.
         </p>
+      </div>
+
+      {/* 2. Nom */}
+      <div className="space-y-1.5">
+        <Label htmlFor="simple-name">Nom du repas</Label>
+        <Input
+          id="simple-name"
+          placeholder="Généré automatiquement depuis les ingrédients"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value)
+            setNameEditedManually(true)
+          }}
+          disabled={loading}
+        />
+      </div>
+
+      {/* 3. Emoji */}
+      <div className="space-y-2">
+        <Label>Emoji</Label>
+        <div className="flex flex-wrap gap-2">
+          {FOOD_EMOJIS.map((e) => (
+            <button
+              key={e}
+              type="button"
+              onClick={() => setEmoji(e)}
+              disabled={loading}
+              className={cn(
+                "h-9 w-9 rounded-md border text-xl transition-colors",
+                emoji === e
+                  ? "border-primary bg-primary/10"
+                  : "border-border hover:bg-secondary",
+              )}
+            >
+              {e}
+            </button>
+          ))}
+        </div>
       </div>
 
       {error && (

--- a/src/presentation/components/SimpleRecipePicker.tsx
+++ b/src/presentation/components/SimpleRecipePicker.tsx
@@ -1,0 +1,202 @@
+import { useState, useCallback } from "react"
+import { Loader2, Plus, Trash2, AlertCircle } from "lucide-react"
+import { Input } from "./ui/input.tsx"
+import { Button } from "./ui/button.tsx"
+import { Label } from "./ui/label.tsx"
+import { Autocomplete } from "./ui/autocomplete.tsx"
+import { useFoods } from "../hooks/useFoods.ts"
+import { useUnits } from "../hooks/useUnits.ts"
+import { useTags } from "../hooks/useTags.ts"
+import { createRecipeUseCase } from "../../infrastructure/container.ts"
+import { mealieApiClient } from "../../infrastructure/mealie/api/index.ts"
+import type { MealieRecipe, RecipeFormIngredient } from "../../shared/types/mealie.ts"
+import { randomFoodEmoji, EXTRAS_EMOJI_KEY, SIMPLE_RECIPE_TAG_SLUG } from "../../shared/utils/recipeEmoji.ts"
+
+interface SimpleRecipePickerProps {
+  onCreated: (recipe: MealieRecipe) => void
+}
+
+function buildEmptyIngredient(): RecipeFormIngredient {
+  return { quantity: "1", unit: "", unitId: undefined, food: "", foodId: undefined, note: "" }
+}
+
+export function SimpleRecipePicker({ onCreated }: SimpleRecipePickerProps) {
+  const { foods } = useFoods()
+  const { units } = useUnits()
+  const { tags } = useTags()
+
+  const [name, setName] = useState("")
+  const [nameEditedManually, setNameEditedManually] = useState(false)
+  const [ingredients, setIngredients] = useState<RecipeFormIngredient[]>([buildEmptyIngredient()])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const foodOptions = foods.map((f) => ({ id: f.id, label: f.name }))
+  const unitOptions = units.map((u) => ({
+    id: u.id,
+    label: u.useAbbreviation && u.abbreviation ? u.abbreviation : u.name,
+  }))
+
+  const updateIngredient = (index: number, patch: Partial<RecipeFormIngredient>) => {
+    setIngredients((prev) => {
+      const next = prev.map((ing, i) => (i === index ? { ...ing, ...patch } : ing))
+      if (!nameEditedManually) {
+        const parts = next.map((ing) => ing.food.trim()).filter(Boolean)
+        setName(parts.join(", "))
+      }
+      return next
+    })
+  }
+
+  const addIngredient = () => setIngredients((prev) => [...prev, buildEmptyIngredient()])
+
+  const removeIngredient = (index: number) => {
+    setIngredients((prev) => {
+      const next = prev.filter((_, i) => i !== index)
+      if (!nameEditedManually) {
+        const parts = next.map((ing) => ing.food.trim()).filter(Boolean)
+        setName(parts.join(", "))
+      }
+      return next
+    })
+  }
+
+  const resolveSimpleTag = useCallback(async (): Promise<{ id: string; name: string; slug: string }> => {
+    const existing = tags.find((t) => t.slug === SIMPLE_RECIPE_TAG_SLUG)
+    if (existing) return { id: existing.id, name: existing.name, slug: existing.slug }
+    return mealieApiClient.post<{ id: string; name: string; slug: string }>(
+      "/api/organizers/tags",
+      { name: SIMPLE_RECIPE_TAG_SLUG },
+    )
+  }, [tags])
+
+  const handleCreate = async () => {
+    const finalName = name.trim() || "Repas simple"
+    setLoading(true)
+    setError(null)
+    try {
+      const simpleTag = await resolveSimpleTag()
+      const recipe = await createRecipeUseCase.execute({
+        name: finalName,
+        description: "",
+        prepTime: "",
+        performTime: "",
+        totalTime: "",
+        recipeIngredient: ingredients,
+        recipeInstructions: [],
+        seasons: [],
+        categories: [],
+        tags: [simpleTag],
+        extras: { [EXTRAS_EMOJI_KEY]: randomFoodEmoji() },
+      })
+      onCreated(recipe)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Impossible de créer le repas simple.")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const hasIngredients = ingredients.some((ing) => ing.food.trim())
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-1.5">
+        <Label htmlFor="simple-name">Nom du repas</Label>
+        <Input
+          id="simple-name"
+          placeholder="Généré automatiquement depuis les ingrédients"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value)
+            setNameEditedManually(true)
+          }}
+          disabled={loading}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Label>Ingrédients</Label>
+          <Button type="button" variant="outline" size="sm" onClick={addIngredient} disabled={loading} className="gap-1.5">
+            <Plus className="h-3.5 w-3.5" />
+            Ajouter
+          </Button>
+        </div>
+
+        <div className="hidden sm:grid sm:grid-cols-[80px_1.5fr_1fr_32px] sm:gap-2 sm:items-center px-1">
+          <span className="text-xs text-muted-foreground font-medium">Qté</span>
+          <span className="text-xs text-muted-foreground font-medium">Aliment</span>
+          <span className="text-xs text-muted-foreground font-medium">Unité</span>
+          <span />
+        </div>
+
+        <div className="space-y-2">
+          {ingredients.map((ing, index) => (
+            <div key={index} className="grid grid-cols-[60px_1.5fr_1fr_32px] sm:grid-cols-[80px_1.5fr_1fr_32px] gap-2 items-center">
+              <Input
+                type="text"
+                inputMode="decimal"
+                placeholder="Qté"
+                value={ing.quantity}
+                onChange={(e) => updateIngredient(index, { quantity: e.target.value })}
+                disabled={loading}
+                className="min-w-0 px-2"
+              />
+              <Autocomplete
+                value={ing.food}
+                onChange={(value, option) => updateIngredient(index, {
+                  food: value,
+                  foodId: option && option.id !== "__create__" ? option.id : undefined,
+                })}
+                options={foodOptions}
+                placeholder="Aliment…"
+                disabled={loading}
+              />
+              <Autocomplete
+                value={ing.unit}
+                onChange={(value, option) => updateIngredient(index, {
+                  unit: value,
+                  unitId: option ? option.id : undefined,
+                })}
+                options={unitOptions}
+                placeholder="Unité…"
+                disabled={loading}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeIngredient(index)}
+                disabled={loading || ingredients.length <= 1}
+                className="shrink-0 text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Une recette avec le tag «&nbsp;simple&nbsp;» sera créée dans Mealie, avec un emoji attribué automatiquement.
+        </p>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <Button
+        type="button"
+        className="w-full gap-2"
+        onClick={() => void handleCreate()}
+        disabled={loading || !hasIngredients}
+      >
+        {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {loading ? "Création en cours…" : "Créer et ajouter au planning"}
+      </Button>
+    </div>
+  )
+}

--- a/src/presentation/components/planning/MealCell.tsx
+++ b/src/presentation/components/planning/MealCell.tsx
@@ -6,7 +6,7 @@ import {
 } from "lucide-react"
 import type { MealieMealPlan } from "../../../shared/types/mealie.ts"
 import { cn } from "../../../lib/utils.ts"
-import { recipeImageUrl } from "../../../shared/utils/image.ts"
+import { RecipeImage } from "../RecipeImage.tsx"
 import { parseServings } from "../../../shared/utils/servings.ts"
 import { getMealServings, getMealVisibleNote } from "./planningUtils.ts"
 
@@ -134,10 +134,11 @@ export function MealCell({
               )}
               <div className="flex items-center gap-2 p-2">
                 {meal.recipe && (
-                  <img
-                    src={recipeImageUrl(meal.recipe, "min-original")}
+                  <RecipeImage
+                    recipe={meal.recipe}
                     alt={name}
                     className="h-[72px] w-[72px] shrink-0 rounded-[var(--radius-md)] object-cover"
+                    fallbackClassName="h-[72px] w-[72px] shrink-0 rounded-[var(--radius-md)]"
                   />
                 )}
                 <span className="line-clamp-4 flex-1 text-[12.5px] font-medium leading-snug">{name}</span>
@@ -284,10 +285,10 @@ export function MealCell({
                       )}
                     >
                       {meal.recipe && (
-                        <img
-                          src={recipeImageUrl(meal.recipe, "min-original")}
-                          alt=""
+                        <RecipeImage
+                          recipe={meal.recipe}
                           className="h-8 w-8 shrink-0 rounded-[var(--radius-sm)] object-cover"
+                          fallbackClassName="h-8 w-8 shrink-0 rounded-[var(--radius-sm)]"
                         />
                       )}
                       <span className="line-clamp-2 leading-snug">

--- a/src/presentation/components/ui/autocomplete.tsx
+++ b/src/presentation/components/ui/autocomplete.tsx
@@ -104,7 +104,7 @@ export function Autocomplete({
       window.removeEventListener("scroll", update, true)
       window.removeEventListener("resize", update)
     }
-  }, [open])
+  }, [open, portalContainer])
 
   const selectItem = (item: AutocompleteOption) => {
     if (item.id === "__create__") {

--- a/src/presentation/components/ui/autocomplete.tsx
+++ b/src/presentation/components/ui/autocomplete.tsx
@@ -19,6 +19,8 @@ interface AutocompleteProps {
   allowCreate?: boolean
   createLabel?: (value: string) => string
   "aria-label"?: string
+  /** Container pour le portal du dropdown (par défaut document.body). Passer le nœud du Dialog pour éviter le blocage Radix. */
+  portalContainer?: HTMLElement | null
 }
 
 export function Autocomplete({
@@ -32,6 +34,7 @@ export function Autocomplete({
   allowCreate = false,
   createLabel = (v) => `Créer "${v}"`,
   "aria-label": ariaLabel,
+  portalContainer,
 }: AutocompleteProps) {
   const [open, setOpen] = useState(false)
   const [highlighted, setHighlighted] = useState(-1)
@@ -69,13 +72,29 @@ export function Autocomplete({
       const spaceBelow = window.innerHeight - rect.bottom
       const dropdownHeight = 192 // max-h-48 = 12rem = 192px
       const showAbove = spaceBelow < dropdownHeight + 8 && rect.top > dropdownHeight
-      setDropdownStyle({
-        position: "fixed",
-        top: showAbove ? rect.top - dropdownHeight - 4 : rect.bottom + 4,
-        left: rect.left,
-        width: rect.width,
-        zIndex: 9999,
-      })
+
+      if (portalContainer && portalContainer !== document.body) {
+        // Le container a un transform CSS → position: fixed est relative à lui.
+        // On soustrait le bounding rect du container pour obtenir les coordonnées locales.
+        const containerRect = portalContainer.getBoundingClientRect()
+        setDropdownStyle({
+          position: "fixed",
+          top: showAbove
+            ? rect.top - dropdownHeight - 4 - containerRect.top
+            : rect.bottom + 4 - containerRect.top,
+          left: rect.left - containerRect.left,
+          width: rect.width,
+          zIndex: 9999,
+        })
+      } else {
+        setDropdownStyle({
+          position: "fixed",
+          top: showAbove ? rect.top - dropdownHeight - 4 : rect.bottom + 4,
+          left: rect.left,
+          width: rect.width,
+          zIndex: 9999,
+        })
+      }
     }
 
     update()
@@ -137,6 +156,7 @@ export function Autocomplete({
       id={`${id}-list`}
       role="listbox"
       style={dropdownStyle}
+      onMouseDown={(e) => e.preventDefault()}
       className={cn(
         "max-h-48 overflow-auto rounded-md border border-border",
         "bg-white dark:bg-zinc-900 text-foreground shadow-md",
@@ -197,7 +217,7 @@ export function Autocomplete({
         )}
       />
 
-      {dropdown && createPortal(dropdown, document.body)}
+      {dropdown && createPortal(dropdown, portalContainer ?? document.body)}
     </div>
   )
 }

--- a/src/presentation/hooks/useDeleteRecipe.ts
+++ b/src/presentation/hooks/useDeleteRecipe.ts
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { deleteRecipeUseCase } from "../../infrastructure/container.ts"
+import { deleteRecipeUseCase, recipeRepository } from "../../infrastructure/container.ts"
 
 export function useDeleteRecipe() {
   const [deleting, setDeleting] = useState(false)
@@ -19,5 +19,15 @@ export function useDeleteRecipe() {
     }
   }
 
-  return { deleteRecipe, deleting, error }
+  const deleteImage = async (slug: string): Promise<boolean> => {
+    try {
+      await recipeRepository.deleteImage(slug)
+      return true
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur inconnue')
+      return false
+    }
+  }
+
+  return { deleteRecipe, deleteImage, deleting, error }
 }

--- a/src/presentation/pages/KioskPage.tsx
+++ b/src/presentation/pages/KioskPage.tsx
@@ -4,8 +4,8 @@ import { Loader2, RefreshCw } from "lucide-react"
 import type { MealieMealPlan } from "../../shared/types/mealie.ts"
 import { getWeekPlanningUseCase } from "../../infrastructure/container.ts"
 import { formatDate } from "../../shared/utils/date.ts"
-import { recipeImageUrl } from "../../shared/utils/image.ts"
 import { cn } from "../../lib/utils.ts"
+import { RecipeImage } from "../components/RecipeImage.tsx"
 import { usePlanningPreferences } from "../hooks/usePlanningPreferences.ts"
 import { getMealVisibleNote } from "../components/planning/planningUtils.ts"
 import { RecipeDetailModal } from "../components/RecipeDetailModal.tsx"
@@ -275,27 +275,18 @@ function MealSlot({ label, meal, isNext, onSelect }: MealSlotProps) {
 
 function RecipeCard({ meal }: { meal: MealieMealPlan }) {
   const recipe = meal.recipe!
-  const [imgError, setImgError] = useState(false)
-  const imageUrl = recipe.id ? recipeImageUrl(recipe, "min-original") : null
   const note = getMealVisibleNote(meal)
 
   return (
     <div className="flex-1 flex flex-col">
       {/* Image */}
       <div className="relative w-full aspect-video bg-secondary overflow-hidden">
-        {imageUrl && !imgError ? (
-          <img
-            src={imageUrl}
-            alt={recipe.name}
-            className="w-full h-full object-cover"
-            loading="lazy"
-            onError={() => setImgError(true)}
-          />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center text-xs text-muted-foreground/50 italic bg-secondary/40">
-            Pas d'image
-          </div>
-        )}
+        <RecipeImage
+          recipe={recipe}
+          alt={recipe.name}
+          className="w-full h-full object-cover"
+          fallbackClassName="w-full h-full text-4xl"
+        />
       </div>
 
       {/* Infos */}

--- a/src/presentation/pages/RecipeDetailPage.tsx
+++ b/src/presentation/pages/RecipeDetailPage.tsx
@@ -33,6 +33,7 @@ import {
   Smile,
 } from "lucide-react"
 import { FOOD_EMOJIS, EXTRAS_EMOJI_KEY } from "../../shared/utils/recipeEmoji.ts"
+import { recipeEmojiStore } from "../../infrastructure/recipe/RecipeEmojiStore.ts"
 import { useState, useRef, useCallback, useEffect, type ChangeEvent } from "react"
 import { CookingMode } from "../components/CookingMode.tsx"
 import type {
@@ -409,6 +410,9 @@ export function RecipeDetailPage() {
       setFormData(buildFormData(updated))
       if (updated.image) setImagePreview(recipeImageUrl(updated, "original"))
       setIsDirty(false)
+      const emoji = formData.extras?.[EXTRAS_EMOJI_KEY]
+      if (emoji) recipeEmojiStore.set(updated.id, emoji)
+      else recipeEmojiStore.remove(updated.id)
     }
   }
 

--- a/src/presentation/pages/RecipeDetailPage.tsx
+++ b/src/presentation/pages/RecipeDetailPage.tsx
@@ -30,7 +30,9 @@ import {
   Sparkles,
   Star,
   Heart,
+  Smile,
 } from "lucide-react"
+import { FOOD_EMOJIS, EXTRAS_EMOJI_KEY } from "../../shared/utils/recipeEmoji.ts"
 import { useState, useRef, useCallback, useEffect, type ChangeEvent } from "react"
 import { CookingMode } from "../components/CookingMode.tsx"
 import type {
@@ -95,6 +97,7 @@ function buildFormData(recipe: MealieRecipe): RecipeFormData {
       .filter((t) => !isSeasonTag(t))
       .map((t) => ({ id: t.id, name: t.name, slug: t.slug })),
     recipeYield: recipe.recipeServings ? String(recipe.recipeServings) : "",
+    extras: recipe.extras ? { ...recipe.extras } : {},
   }
 }
 
@@ -587,6 +590,48 @@ export function RecipeDetailPage() {
                     <option key={p.value} value={p.value}>{p.label}</option>
                   ))}
                 </select>
+              </div>
+            </div>
+
+            {/* Emoji illustration */}
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Smile className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">Illustration (emoji)</span>
+                <span className="text-xs text-muted-foreground">— affiché si pas d'image</span>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => {
+                    const next = { ...(formData.extras ?? {}) }
+                    delete next[EXTRAS_EMOJI_KEY]
+                    patch({ extras: next })
+                  }}
+                  className={cn(
+                    "h-8 px-2.5 rounded-md border text-xs font-medium transition-colors",
+                    !formData.extras?.[EXTRAS_EMOJI_KEY]
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border text-muted-foreground hover:bg-secondary",
+                  )}
+                >
+                  Aucun
+                </button>
+                {FOOD_EMOJIS.map((emoji) => (
+                  <button
+                    key={emoji}
+                    type="button"
+                    onClick={() => patch({ extras: { ...(formData.extras ?? {}), [EXTRAS_EMOJI_KEY]: emoji } })}
+                    className={cn(
+                      "h-8 w-8 rounded-md border text-lg transition-colors",
+                      formData.extras?.[EXTRAS_EMOJI_KEY] === emoji
+                        ? "border-primary bg-primary/10"
+                        : "border-border hover:bg-secondary",
+                    )}
+                  >
+                    {emoji}
+                  </button>
+                ))}
               </div>
             </div>
 

--- a/src/presentation/pages/RecipeDetailPage.tsx
+++ b/src/presentation/pages/RecipeDetailPage.tsx
@@ -141,7 +141,7 @@ export function RecipeDetailPage() {
   const { units } = useUnits()
   const { updateRecipe, loading: saving, error: saveError } = useRecipeForm()
   const { fetchAiImage } = useAiImage()
-  const { deleteRecipe, deleting } = useDeleteRecipe()
+  const { deleteRecipe, deleteImage, deleting } = useDeleteRecipe()
   const { updateNutrition, loading: nutritionSaving, error: nutritionSaveError } = useUpdateNutrition()
   const navigate = useNavigate()
   const [aiProvider, setAiProvider] = useState<ImageProvider>("wikipedia-en")
@@ -151,6 +151,7 @@ export function RecipeDetailPage() {
 
   const [formData, setFormData] = useState<RecipeFormData | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
+  const [removingImage, setRemovingImage] = useState(false)
   const [isDirty, setIsDirty] = useState(false)
   const [cookingMode, setCookingMode] = useState(false)
   const [nutritionLoading, setNutritionLoading] = useState(false)
@@ -194,6 +195,14 @@ export function RecipeDetailPage() {
   }, [])
 
   // ─── Image ─────────────────────────────────────────────────────────────────
+
+  const handleDeleteImage = async () => {
+    if (!recipe) return
+    setRemovingImage(true)
+    await deleteImage(recipe.slug)
+    setImagePreview(null)
+    setRemovingImage(false)
+  }
 
   const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -568,6 +577,24 @@ export function RecipeDetailPage() {
                 className="hidden"
                 onChange={handleImageChange}
               />
+
+              {/* Supprimer l'image */}
+              {imagePreview && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void handleDeleteImage()}
+                  disabled={removingImage}
+                  className="gap-1.5 text-destructive hover:text-destructive"
+                >
+                  {removingImage
+                    ? <Loader2 className="h-4 w-4 animate-spin" />
+                    : <Trash2 className="h-4 w-4" />
+                  }
+                  Supprimer l'image
+                </Button>
+              )}
 
               {/* Bouton photo via IA — WIP */}
               <div className="flex items-center gap-2 flex-wrap">

--- a/src/presentation/pages/RecipesPage.tsx
+++ b/src/presentation/pages/RecipesPage.tsx
@@ -7,9 +7,10 @@ import { getCaloriesFromTags } from "../../shared/utils/calorie.ts"
 import { useGridColumns } from "../hooks/useGridColumns.ts"
 import { RecipeCard } from "../components/RecipeCard.tsx"
 import { Button } from "../components/ui/button.tsx"
-import {Loader2, AlertCircle, UtensilsCrossed, Plus, PenLine, } from "lucide-react"
+import {Loader2, AlertCircle, UtensilsCrossed, Plus, PenLine, ChefHat } from "lucide-react"
 import type { MealieRecipe, Season } from "../../shared/types/mealie.ts"
 import { getRecipeSeasonsFromTags } from "../../shared/utils/season.ts"
+import { isSimpleRecipe } from "../../shared/utils/recipeEmoji.ts"
 import { getEnv } from "../../shared/utils/env.ts"
 import { getRecipesUseCase, getRecipeUseCase } from "../../infrastructure/container.ts"
 import { cn } from "../../lib/utils.ts"
@@ -25,6 +26,7 @@ export function RecipesPage() {
   const [maxTotalTime, setMaxTotalTime] = useState<number | undefined>(undefined)
   const [maxCalories, setMaxCalories] = useState<number | undefined>(undefined)
   const [selectedSeasons, setSelectedSeasons] = useState<Season[]>([])
+  const [showSimple, setShowSimple] = useState(false)
   const [noIngredients, setNoIngredients] = useState(false)
   const [noIngredientRecipes, setNoIngredientRecipes] = useState<MealieRecipe[] | null>(null)
   const [noIngredientsLoading, setNoIngredientsLoading] = useState(false)
@@ -168,6 +170,9 @@ export function RecipesPage() {
       : recipes
 
     return base.filter((recipe) => {
+      // Masquer les recettes simples par défaut
+      if (!showSimple && isSimpleRecipe(recipe)) return false
+
       // =====================
       // SAISONS
       // =====================
@@ -229,6 +234,7 @@ export function RecipesPage() {
     selectedTags,
     maxTotalTime,
     maxCalories,
+    showSimple,
   ])
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [tagSearch, setTagSearch] = useState("")
@@ -284,6 +290,24 @@ export function RecipesPage() {
                 {columns}
               </span>
             </div>
+
+            {/* Toggle recettes simples */}
+            <button
+              type="button"
+              onClick={() => setShowSimple((v) => !v)}
+              title={showSimple ? "Masquer les repas simples" : "Afficher les repas simples"}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-[var(--radius-lg)]",
+                "border px-3 py-1.5 text-sm font-semibold transition-all duration-150",
+                "shadow-subtle",
+                showSimple
+                  ? "border-primary/60 bg-primary/10 text-primary"
+                  : "border-border bg-card text-muted-foreground hover:bg-secondary hover:text-foreground",
+              )}
+            >
+              <ChefHat className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Simples</span>
+            </button>
 
             {/* Importer depuis Mealie */}
             <a

--- a/src/shared/types/mealie.ts
+++ b/src/shared/types/mealie.ts
@@ -98,6 +98,7 @@ export interface RecipeFormData {
   seasons: Season[]
   categories: Array<{ id: string; name: string; slug: string }>
   tags: Array<{ id: string; name: string; slug: string }>
+  extras?: Record<string, string>
 }
 
 export interface MealieRecipe {

--- a/src/shared/utils/recipeEmoji.ts
+++ b/src/shared/utils/recipeEmoji.ts
@@ -1,4 +1,5 @@
 import type { MealieRecipe } from "../types/mealie.ts"
+import { recipeEmojiStore } from "../../infrastructure/recipe/RecipeEmojiStore.ts"
 
 export const EXTRAS_EMOJI_KEY = "bonap_emoji"
 export const SIMPLE_RECIPE_TAG_SLUG = "simple"
@@ -14,8 +15,8 @@ export function randomFoodEmoji(): string {
   return FOOD_EMOJIS[Math.floor(Math.random() * FOOD_EMOJIS.length)]
 }
 
-export function getRecipeEmoji(recipe: Pick<MealieRecipe, "extras">): string | null {
-  return recipe.extras?.[EXTRAS_EMOJI_KEY] ?? null
+export function getRecipeEmoji(recipe: Pick<MealieRecipe, "id" | "extras">): string | null {
+  return recipe.extras?.[EXTRAS_EMOJI_KEY] ?? recipeEmojiStore.get(recipe.id) ?? null
 }
 
 export function isSimpleRecipe(recipe: Pick<MealieRecipe, "tags">): boolean {

--- a/src/shared/utils/recipeEmoji.ts
+++ b/src/shared/utils/recipeEmoji.ts
@@ -1,0 +1,23 @@
+import type { MealieRecipe } from "../types/mealie.ts"
+
+export const EXTRAS_EMOJI_KEY = "bonap_emoji"
+export const SIMPLE_RECIPE_TAG_SLUG = "simple"
+
+export const FOOD_EMOJIS = [
+  "🍕", "🍝", "🥗", "🍲", "🥘", "🍛", "🍜", "🥩", "🐟", "🥦",
+  "🍳", "🥚", "🧆", "🫕", "🥙", "🌮", "🫔", "🥪", "🍱", "🥫",
+  "🍖", "🍗", "🥓", "🫛", "🥕", "🧅", "🧄", "🌽", "🍅", "🥑",
+  "🫚", "🧇", "🥞", "🫓", "🥐", "🍞", "🥨", "🧀", "🐠", "🦐",
+]
+
+export function randomFoodEmoji(): string {
+  return FOOD_EMOJIS[Math.floor(Math.random() * FOOD_EMOJIS.length)]
+}
+
+export function getRecipeEmoji(recipe: Pick<MealieRecipe, "extras">): string | null {
+  return recipe.extras?.[EXTRAS_EMOJI_KEY] ?? null
+}
+
+export function isSimpleRecipe(recipe: Pick<MealieRecipe, "tags">): boolean {
+  return recipe.tags?.some((t) => t.slug === SIMPLE_RECIPE_TAG_SLUG) ?? false
+}


### PR DESCRIPTION
## Summary
Fixes #89

### Repas simple
- Nouvel onglet **Repas simple** dans le dialog de choix de recette du planning
- Saisie d'ingrédients (food + unité + quantité) avec autocomplete, même composant que le formulaire recette
- Nom auto-généré depuis les ingrédients (modifiable manuellement)
- Crée une vraie recette Mealie avec le tag `simple` (créé automatiquement si absent)
- Un emoji aléatoire est attribué automatiquement (`extras.bonap_emoji`)

### Illustrations emoji
- À la création d'une recette (simple ou non), un emoji aléatoire peut être stocké dans `extras.bonap_emoji`
- `RecipeCard` et thumbnails du picker utilisent cet emoji quand l'image est absente
- `RecipeFormDialog` : nouvelle section "Illustration (emoji)" pour choisir ou retirer l'emoji

### Filtre recettes simples
- Bouton **Simples** dans la toolbar de RecipesPage pour afficher/masquer les recettes taguées `simple`
- Masquées par défaut pour ne pas polluer la liste principale

## Test plan
- [ ] Planning → `+` → onglet "Repas simple" → ajouter des ingrédients → créer → vérifier que la recette apparaît dans le planning
- [ ] Vérifier que le tag `simple` est créé dans Mealie et associé à la recette
- [ ] Recettes → bouton "Simples" masqué par défaut, visible au clic
- [ ] RecipeFormDialog → section "Illustration (emoji)" → choisir un emoji → sauvegarder → vérifier que la carte affiche l'emoji quand pas d'image
- [ ] RecipeCard sans image : emoji depuis `extras.bonap_emoji` affiché, sinon 🍽️

🤖 Generated with [Claude Code](https://claude.com/claude-code)