### PR TITLE
fix(emoji): filter out unsupported emojis on older Windows/WebView

### DIFF
--- a/src/presentation/components/SimpleRecipePicker.tsx
+++ b/src/presentation/components/SimpleRecipePicker.tsx
@@ -9,7 +9,7 @@ import { useTags } from "../hooks/useTags.ts"
 import { createRecipeUseCase } from "../../infrastructure/container.ts"
 import { mealieApiClient } from "../../infrastructure/mealie/api/index.ts"
 import type { MealieRecipe, RecipeFormIngredient } from "../../shared/types/mealie.ts"
-import { randomFoodEmoji, FOOD_EMOJIS, EXTRAS_EMOJI_KEY, SIMPLE_RECIPE_TAG_SLUG } from "../../shared/utils/recipeEmoji.ts"
+import { randomFoodEmoji, getSupportedFoodEmojis, getUnsupportedEmojiCount, EXTRAS_EMOJI_KEY, SIMPLE_RECIPE_TAG_SLUG } from "../../shared/utils/recipeEmoji.ts"
 import { recipeEmojiStore } from "../../infrastructure/recipe/RecipeEmojiStore.ts"
 import { cn } from "../../lib/utils.ts"
 
@@ -163,7 +163,7 @@ export function SimpleRecipePicker({ onCreated, dropdownContainer }: SimpleRecip
       <div className="space-y-2">
         <Label>Emoji</Label>
         <div className="flex flex-wrap gap-2">
-          {FOOD_EMOJIS.map((e) => (
+          {getSupportedFoodEmojis().map((e) => (
             <button
               key={e}
               type="button"
@@ -180,6 +180,11 @@ export function SimpleRecipePicker({ onCreated, dropdownContainer }: SimpleRecip
             </button>
           ))}
         </div>
+        {getUnsupportedEmojiCount() > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {getUnsupportedEmojiCount()} emoji{getUnsupportedEmojiCount() > 1 ? "s" : ""} masqué{getUnsupportedEmojiCount() > 1 ? "s" : ""} — non disponibles sur cet appareil.
+          </p>
+        )}
       </div>
 
       {error && (

--- a/src/shared/utils/recipeEmoji.ts
+++ b/src/shared/utils/recipeEmoji.ts
@@ -11,8 +11,45 @@ export const FOOD_EMOJIS = [
   "🫚", "🧇", "🥞", "🫓", "🥐", "🍞", "🥨", "🧀", "🐠", "🦐",
 ]
 
+// Détecte si un emoji est rendu visuellement par le système (pixels colorés sur canvas).
+// Les emojis non supportés s'affichent en carré blanc (tofu) sans pixel coloré.
+function isEmojiRendered(emoji: string): boolean {
+  try {
+    const canvas = document.createElement("canvas")
+    canvas.width = 20
+    canvas.height = 20
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return true
+    ctx.font = "16px serif"
+    ctx.fillText(emoji, 0, 16)
+    const { data } = ctx.getImageData(0, 0, 20, 20)
+    for (let i = 0; i < data.length; i += 4) {
+      const [r, g, b, a] = [data[i], data[i + 1], data[i + 2], data[i + 3]]
+      // Pixel coloré et non-transparent = emoji rendu correctement
+      if (a > 10 && (Math.abs(r - g) > 10 || Math.abs(r - b) > 10 || Math.abs(g - b) > 10)) return true
+    }
+    return false
+  } catch {
+    return true
+  }
+}
+
+let _supportedEmojis: string[] | null = null
+
+export function getSupportedFoodEmojis(): string[] {
+  if (_supportedEmojis) return _supportedEmojis
+  _supportedEmojis = FOOD_EMOJIS.filter(isEmojiRendered)
+  return _supportedEmojis
+}
+
+export function getUnsupportedEmojiCount(): number {
+  return FOOD_EMOJIS.length - getSupportedFoodEmojis().length
+}
+
 export function randomFoodEmoji(): string {
-  return FOOD_EMOJIS[Math.floor(Math.random() * FOOD_EMOJIS.length)]
+  const supported = getSupportedFoodEmojis()
+  const list = supported.length > 0 ? supported : FOOD_EMOJIS
+  return list[Math.floor(Math.random() * list.length)]
 }
 
 export function getRecipeEmoji(recipe: Pick<MealieRecipe, "id" | "extras">): string | null {


### PR DESCRIPTION
## Summary

- Ajoute une détection canvas à l'exécution : chaque emoji est dessiné sur un canvas 20×20 et on vérifie la présence de pixels colorés. Un emoji non supporté (tofu = carré blanc) ne produit pas de pixels colorés.
- Seuls les emojis supportés sont affichés dans le picker de `SimpleRecipePicker`.
- Un message discret s'affiche si des emojis ont été masqués : _"N emojis masqués — non disponibles sur cet appareil."_
- `randomFoodEmoji()` pioche aussi uniquement dans les emojis supportés.
- Le résultat de la détection est mis en cache (`_supportedEmojis`) pour ne faire le scan qu'une seule fois.

## Test plan
- [ ] Sur un Windows récent : tous les emojis s'affichent, pas de message
- [ ] Sur un vieux Windows / Android WebView : les tofus disparaissent, message affiché
- [ ] CI passe

Closes #100