### PR TITLE
fix(shopping): use food field for habituels instead of note only

### DIFF
--- a/src/presentation/components/shopping/HabituelItemRow.tsx
+++ b/src/presentation/components/shopping/HabituelItemRow.tsx
@@ -27,13 +27,14 @@ export function HabituelItemRow({ item, labels, cartItems, onAddToCart, onDelete
     return i.note?.toLowerCase() === item.note?.toLowerCase()
   })
   const [editing, setEditing] = useState(false)
-  const [editValue, setEditValue] = useState(item.note ?? "")
+  const displayName = item.foodName ?? item.note ?? ""
+  const [editValue, setEditValue] = useState(displayName)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const name = item.note ?? "Article sans nom"
+  const name = displayName || "Article sans nom"
 
   const handleEdit = () => {
-    setEditValue(item.note ?? "")
+    setEditValue(displayName)
     setEditing(true)
     setTimeout(() => inputRef.current?.focus(), 0)
   }

--- a/src/presentation/hooks/useShopping.ts
+++ b/src/presentation/hooks/useShopping.ts
@@ -9,6 +9,8 @@ import {
   deleteItemUseCase,
   clearListUseCase,
   shoppingRepository,
+  getFoodsUseCase,
+  createFoodUseCase,
 } from "../../infrastructure/container.ts"
 import { extractFoodKey } from "../../shared/utils/food.ts"
 import { foodLabelStore } from "../../infrastructure/shopping/FoodLabelStore.ts"
@@ -269,16 +271,22 @@ export function useShopping() {
       shoppingListId: habituelsListId,
       checked: false,
       position: 0,
-      isFood: false,
+      isFood: true,
       note,
+      foodName: note,
       source: "mealie",
     }
     setHabituelsItems((prev) => [...prev, tempItem])
     try {
+      const foods = await getFoodsUseCase.execute()
+      const normalizedNote = note.trim().toLowerCase()
+      const existing = foods.find((f) => f.name.toLowerCase() === normalizedNote)
+      const food = existing ?? await createFoodUseCase.execute(note.trim())
       await shoppingRepository.addItem(habituelsListId, {
         shoppingListId: habituelsListId,
         note,
-        isFood: false,
+        isFood: true,
+        foodId: food.id,
         labelId,
       })
       const result = await getShoppingItemsUseCase.execute()


### PR DESCRIPTION
Resolve food by name (create on the fly if absent) when adding a habituel, so Mealie stores a proper food reference instead of a free text note. Display uses foodName > note priority to avoid showing Mealie-generated quantity strings from the display field.

Closes #98

## Description

<!-- Décrivez les changements apportés et pourquoi -->

## Type de changement

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring (pas de changement de comportement)
- [ ] Documentation
- [ ] Maintenance (deps, CI, config...)

## Tests

- [ ] `npm run lint` passe sans erreur
- [ ] `npm run build` passe sans erreur
- [ ] Testé manuellement sur une instance Mealie
- [ ] Tests e2e passent (`npx playwright test`) — si applicable

## Checklist

- [ ] La branche est créée depuis `main` (pas de push direct sur `main`)
- [ ] Les commits suivent la convention `type(scope): message`
- [ ] La PR pointe vers `main`
