### PR TITLE
fix(api): catch AbortError and surface a readable timeout message

### DIFF
--- a/src/infrastructure/mealie/api/MealieApiClient.ts
+++ b/src/infrastructure/mealie/api/MealieApiClient.ts
@@ -122,6 +122,11 @@ export class MealieApiClient implements IMealieApiClient {
 
       if (response.status === 204) return undefined as T
       return (await response.json()) as T
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        throw new MealieApiError(`La requête ${method} ${path} a expiré`, 0)
+      }
+      throw err
     } finally {
       clearTimeout(timer)
     }


### PR DESCRIPTION
## Summary

- Intercepte le `DOMException` `AbortError` dans `fetchOnce` de `MealieApiClient`
- Le retransmet en `MealieApiError` avec le message `"La requête METHOD /path a expiré"` au lieu du cryptique `"signal is aborted without reason"`
- Couvre les deux `AbortController` présents dans le client HTTP (requêtes standard + SSE)

## Cause

Quand le timeout expire, `controller.abort()` est appelé sans argument, ce qui fait lever un `DOMException { name: "AbortError", message: "signal is aborted without reason" }` par le navigateur. Ce message natif n'était pas intercepté et remontait tel quel dans l'UI.

## Test plan

- [ ] Simuler un réseau lent (DevTools → Network throttling) et vérifier que l'erreur affichée est lisible
- [ ] Vérifier que les autres erreurs (401, 404, 5xx) ne sont pas affectées

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)