### PR TITLE
fix: add OpenCode proxy locations to standalone nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,38 @@ server {
         proxy_read_timeout 120s;
     }
 
+    # Proxy OpenCode Go (CORS-bloqué côté navigateur)
+    location ^~ /api/opencode-go/ {
+        resolver 1.1.1.1 valid=10s;
+        rewrite ^/api/opencode-go/(.*) /$1 break;
+        proxy_pass https://opencode.ai/zen/go/v1;
+        proxy_http_version 1.1;
+        proxy_ssl_server_name on;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 300s;
+    }
+
+    # Proxy OpenCode Zen (CORS-bloqué côté navigateur)
+    location ^~ /api/opencode/ {
+        resolver 1.1.1.1 valid=10s;
+        rewrite ^/api/opencode/(.*) /$1 break;
+        proxy_pass https://opencode.ai/zen/v1;
+        proxy_http_version 1.1;
+        proxy_ssl_server_name on;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 300s;
+    }
+
     # Proxy Ollama local (utile si l'UI utilise /api/ollama)
     location ^~ /api/ollama/ {
         resolver 127.0.0.11 valid=10s;

--- a/src/infrastructure/llm/AssistantService.ts
+++ b/src/infrastructure/llm/AssistantService.ts
@@ -26,10 +26,7 @@ function getOllamaFetchConfig(
 }
 
 function getOpenCodeBaseUrl(go: boolean): string {
-  if (import.meta.env.DEV) {
-    return go ? '/api/opencode-go' : '/api/opencode'
-  }
-  return go ? 'https://opencode.ai/zen/go/v1' : 'https://opencode.ai/zen/v1'
+  return go ? '/api/opencode-go' : '/api/opencode'
 }
 
 // ─── Public types ─────────────────────────────────────────────────────────────

--- a/src/infrastructure/llm/LLMService.ts
+++ b/src/infrastructure/llm/LLMService.ts
@@ -21,12 +21,9 @@ function getOllamaFetchConfig(
 }
 
 // OpenCode ne renvoie pas Access-Control-Allow-Origin → on passe par le proxy
-// Vite (dev) ou nginx (prod addon HA) pour éviter l'erreur CORS navigateur.
+// Vite (dev) ou nginx (prod : Docker/HA addon) pour éviter l'erreur CORS navigateur.
 function getOpenCodeBaseUrl(go: boolean): string {
-  if (import.meta.env.DEV) {
-    return go ? '/api/opencode-go' : '/api/opencode'
-  }
-  return go ? 'https://opencode.ai/zen/go/v1' : 'https://opencode.ai/zen/v1'
+  return go ? '/api/opencode-go' : '/api/opencode'
 }
 
 /**


### PR DESCRIPTION
Le nginx.conf standalone (Docker) navait pas les proxy locations pour OpenCode Go/Zen, contrairement au ha-addon/nginx.conf. En production, getOpenCodeBaseUrl() retournait l URL directe sans support CORS → le navigateur bloquait la requete.

Changements :
- nginx.conf : ajout des locations /api/opencode-go/ et /api/opencode/ (proxy vers opencode.ai)
- LLMService.ts / AssistantService.ts : getOpenCodeBaseUrl() retourne toujours le path proxy, meme en production (CORS impossible cote navigateur)