### PR TITLE
fix(portions): lire les portions depuis recipeServings et non recipeYield

### DIFF
--- a/e2e/fixtures/mealie.ts
+++ b/e2e/fixtures/mealie.ts
@@ -25,6 +25,11 @@ export const RECIPE_PIZZA = {
   prepTime: "PT30M",
   performTime: "PT45M",
   totalTime: "PT1H15M",
+  // Mealie >= 2 : le nombre est dans recipeServings, recipeYield n'est
+  // que le libellé d'unité (vérifié sur une instance v3.22.0).
+  recipeServings: 4,
+  recipeYieldQuantity: 4,
+  recipeYield: "personnes",
   recipeIngredient: [
     {
       referenceId: "ri1",
@@ -74,6 +79,9 @@ export const RECIPE_SALADE = {
   prepTime: "PT15M",
   performTime: null,
   totalTime: "PT15M",
+  // Recette « legacy » : nombre stocké dans recipeYield, comme avant que
+  // Mealie ne sépare les champs. Doit rester lisible.
+  recipeYield: "2 personnes",
   recipeIngredient: [
     {
       referenceId: "ri4",
@@ -130,6 +138,9 @@ export const MEALPLANS_RESPONSE = {
         slug: "pizza-maison",
         name: "Pizza maison",
         description: "Une pizza classique",
+        recipeServings: 4,
+        recipeYieldQuantity: 4,
+        recipeYield: "personnes",
       },
     },
     {
@@ -143,6 +154,7 @@ export const MEALPLANS_RESPONSE = {
         slug: "salade-nicoise",
         name: "Salade niçoise",
         description: "Une salade fraîche",
+        recipeYield: "2 personnes",
       },
     },
   ],

--- a/e2e/planning.spec.ts
+++ b/e2e/planning.spec.ts
@@ -147,4 +147,32 @@ test.describe("Planning", () => {
       await expect(page.getByRole("heading", { name: "Planning" })).toBeVisible()
     })
   })
+
+  test.describe("Portions (issue #14)", () => {
+    test("lit les portions d'une recette Mealie v2+ (nombre dans recipeServings)", async ({ page }) => {
+      await page.goto("/planning")
+      const table = page.locator("table")
+      await expect(table.getByText("Pizza maison")).toBeVisible({ timeout: 8000 })
+
+      // La pizza a recipeServings: 4 et recipeYield: "personnes" (pas de chiffre).
+      await expect(table.getByText("4 pers.").first()).toBeVisible()
+    })
+
+    test("lit encore les recettes legacy (nombre dans recipeYield)", async ({ page }) => {
+      await page.goto("/planning")
+      const table = page.locator("table")
+      await expect(table.getByText("Salade niçoise")).toBeVisible({ timeout: 8000 })
+
+      // La salade n'a que recipeYield: "2 personnes".
+      await expect(table.getByText("2 pers.").first()).toBeVisible()
+    })
+
+    test("n'affiche plus 'Définir les portions' quand la recette en a", async ({ page }) => {
+      await page.goto("/planning")
+      const table = page.locator("table")
+      await expect(table.getByText("Pizza maison")).toBeVisible({ timeout: 8000 })
+
+      await expect(table.getByText("Définir les portions dans la recette")).toHaveCount(0)
+    })
+  })
 })

--- a/src/presentation/components/RecipeDetailModal.tsx
+++ b/src/presentation/components/RecipeDetailModal.tsx
@@ -11,7 +11,7 @@ import { Button } from "./ui/button.tsx"
 import { CookingMode } from "./CookingMode.tsx"
 import { addMealUseCase, deleteMealUseCase } from "../../infrastructure/container.ts"
 import type { MealieIngredient, MealieInstruction } from "../../shared/types/mealie.ts"
-import { parseServings } from "../../shared/utils/servings.ts"
+import { getRecipeServings } from "../../shared/utils/servings.ts"
 
 interface RecipeDetailModalProps {
   slug: string | null
@@ -47,7 +47,7 @@ export function RecipeDetailModal({ slug, targetServings, onOpenChange }: Recipe
       name: recipe.name,
       ingredients: recipe.recipeIngredient ?? [],
       instructions: recipe.recipeInstructions ?? [],
-      baseServings: parseServings(recipe.recipeYield),
+      baseServings: getRecipeServings(recipe),
       targetServings,
     })
     onOpenChange(false)

--- a/src/presentation/components/RecipeFormDialog.tsx
+++ b/src/presentation/components/RecipeFormDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { Loader2, AlertCircle, Plus, Trash2, GripVertical, Smile } from "lucide-react"
 import { FOOD_EMOJIS, EXTRAS_EMOJI_KEY } from "../../shared/utils/recipeEmoji.ts"
+import { getRecipeServings } from "../../shared/utils/servings.ts"
 import {
   Dialog,
   DialogContent,
@@ -94,7 +95,7 @@ function buildInitialFormData(recipe?: MealieRecipe): RecipeFormData {
     prepTime: parsePrepTimeToMinutes(recipe?.prepTime),
     performTime: parsePrepTimeToMinutes(recipe?.performTime),
     totalTime: parsePrepTimeToMinutes(recipe?.totalTime),
-    recipeYield: recipe?.recipeServings ? String(recipe.recipeServings) : "",
+    recipeYield: getRecipeServings(recipe)?.toString() ?? "",
     recipeIngredient: buildInitialIngredients(recipe),
     recipeInstructions: buildInitialInstructions(recipe),
     seasons: getRecipeSeasonsFromTags(recipe?.tags),

--- a/src/presentation/components/planning/MealCell.tsx
+++ b/src/presentation/components/planning/MealCell.tsx
@@ -7,7 +7,7 @@ import {
 import type { MealieMealPlan } from "../../../shared/types/mealie.ts"
 import { cn } from "../../../lib/utils.ts"
 import { RecipeImage } from "../RecipeImage.tsx"
-import { parseServings } from "../../../shared/utils/servings.ts"
+import { getRecipeServings } from "../../../shared/utils/servings.ts"
 import { getMealServings, getMealVisibleNote } from "./planningUtils.ts"
 
 export interface MealCellProps {
@@ -96,7 +96,7 @@ export function MealCell({
         {meals.map((meal) => {
           const name = meal.recipe?.name ?? meal.title ?? "Sans titre"
           const mealServings = getMealServings(meal)
-          const baseServings = parseServings(meal.recipe?.recipeYield)
+          const baseServings = getRecipeServings(meal.recipe)
           const isSelected = selectionMode && (selectedMealIds?.has(meal.id) ?? false)
           return (
             <div

--- a/src/presentation/components/planning/planningUtils.ts
+++ b/src/presentation/components/planning/planningUtils.ts
@@ -1,11 +1,11 @@
 import type { MealieMealPlan, MealieRecipe } from "../../../shared/types/mealie.ts"
-import { decodeServingsFromText, parseServings } from "../../../shared/utils/servings.ts"
+import { decodeServingsFromText, getRecipeServings } from "../../../shared/utils/servings.ts"
 import { getRecipesUseCase } from "../../../infrastructure/container.ts"
 
 export function getMealServings(meal: MealieMealPlan): number | undefined {
   const fromText = decodeServingsFromText(meal.text).servings
   if (fromText && fromText > 0) return fromText
-  const base = parseServings(meal.recipe?.recipeYield)
+  const base = getRecipeServings(meal.recipe)
   return base && base > 0 ? base : undefined
 }
 
@@ -14,7 +14,7 @@ export function getMealVisibleNote(meal: MealieMealPlan): string {
 }
 
 export function getInitialServingsForNewMeal(recipe: MealieRecipe | undefined, familySize: number): number | undefined {
-  const recipeBase = parseServings(recipe?.recipeYield)
+  const recipeBase = getRecipeServings(recipe)
   if (!recipeBase || recipeBase <= 0) return undefined
   return familySize > 0 ? familySize : recipeBase
 }

--- a/src/presentation/pages/PlanningPage.tsx
+++ b/src/presentation/pages/PlanningPage.tsx
@@ -26,7 +26,7 @@ import { formatDate } from "../../shared/utils/date.ts"
 import { cn } from "../../lib/utils.ts"
 import { recipeImageUrl } from "../../shared/utils/image.ts"
 import { generateBalancedMealPlan } from "../../shared/utils/balancedMealPlanner.ts"
-import { parseServings, encodeServingsInText } from "../../shared/utils/servings.ts"
+import { getRecipeServings, encodeServingsInText } from "../../shared/utils/servings.ts"
 
 const DAY_LABELS = ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"]
 
@@ -123,7 +123,7 @@ export function PlanningPage() {
     }
     const meals = filtered.map((m) => {
       const selected = getMealServings(m)
-      const base = parseServings(m.recipe?.recipeYield)
+      const base = getRecipeServings(m.recipe)
       const servingsRatio = selected && base && base > 0 ? selected / base : 1
       return { slug: m.recipe!.slug, recipeName: m.recipe!.name, servingsRatio, date: m.date }
     })

--- a/src/presentation/pages/RecipeDetailPage.tsx
+++ b/src/presentation/pages/RecipeDetailPage.tsx
@@ -47,7 +47,7 @@ import type {
 } from "../../shared/types/mealie.ts"
 import { SEASONS, SEASON_LABELS } from "../../shared/types/mealie.ts"
 import { getRecipeSeasonsFromTags, isSeasonTag } from "../../shared/utils/season.ts"
-import { parseServings } from "../../shared/utils/servings.ts"
+import { getRecipeServings, parseServings } from "../../shared/utils/servings.ts"
 import { cn } from "../../lib/utils.ts"
 import { MarkdownContent } from "../components/MarkdownContent.tsx"
 
@@ -97,7 +97,7 @@ function buildFormData(recipe: MealieRecipe): RecipeFormData {
     tags: (recipe.tags ?? [])
       .filter((t) => !isSeasonTag(t))
       .map((t) => ({ id: t.id, name: t.name, slug: t.slug })),
-    recipeYield: recipe.recipeServings ? String(recipe.recipeServings) : "",
+    recipeYield: getRecipeServings(recipe)?.toString() ?? "",
     extras: recipe.extras ? { ...recipe.extras } : {},
   }
 }
@@ -442,7 +442,7 @@ export function RecipeDetailPage() {
           recipeName={recipe.name}
           ingredients={recipe.recipeIngredient ?? []}
           instructions={recipe.recipeInstructions ?? []}
-          baseServings={parseServings(recipe.recipeYield)}
+          baseServings={getRecipeServings(recipe)}
           targetServings={parseServings(formData.recipeYield)}
           onClose={() => setCookingMode(false)}
         />

--- a/src/shared/utils/balancedMealPlanner.ts
+++ b/src/shared/utils/balancedMealPlanner.ts
@@ -1,6 +1,6 @@
 import type { MealieMealPlan, MealieRecipe } from "../types/mealie.ts"
 import { getCaloriesFromTags } from "./calorie.ts"
-import { parseServings } from "./servings.ts"
+import { getRecipeServings } from "./servings.ts"
 
 export interface AutoPlanSlot {
   date: string
@@ -78,7 +78,7 @@ function normalizeKey(value: string): string {
 }
 
 function getNutritionProfile(recipe: MealieRecipe): NutritionProfile {
-  const servings = parseServings(recipe.recipeYield)
+  const servings = getRecipeServings(recipe)
   // Normalise par portion (valeurs par personne) pour comparer aux MEAL_TARGETS qui sont par personne.
   // On ignore familySize ici : on veut scorer la valeur nutritionnelle d'une portion adulte.
   const divisor = (servings && servings > 0) ? servings : 1

--- a/src/shared/utils/servings.test.ts
+++ b/src/shared/utils/servings.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest"
+import type { MealieRecipe } from "../types/mealie.ts"
+import {
+  getRecipeServings,
+  parseServings,
+  encodeServingsInText,
+  decodeServingsFromText,
+  formatQuantity,
+} from "./servings.ts"
+
+function makeRecipe(overrides: Partial<MealieRecipe> = {}): MealieRecipe {
+  return { id: "r1", slug: "test", name: "Test", ...overrides }
+}
+
+describe("parseServings", () => {
+  it("extrait le premier nombre trouvé", () => {
+    expect(parseServings("4")).toBe(4)
+    expect(parseServings("4 personnes")).toBe(4)
+    expect(parseServings("pour 4")).toBe(4)
+    expect(parseServings("4-6 personnes")).toBe(4)
+  })
+
+  it("retourne undefined si aucun nombre", () => {
+    expect(parseServings(undefined)).toBeUndefined()
+    expect(parseServings("")).toBeUndefined()
+    expect(parseServings("personnes")).toBeUndefined()
+  })
+})
+
+describe("getRecipeServings", () => {
+  // Mealie >= 2 stocke le nombre dans recipeServings et garde recipeYield
+  // comme simple libellé d'unité ("personnes", "parts"…).
+  it("lit recipeServings en priorité (format Mealie v2/v3)", () => {
+    const recipe = makeRecipe({
+      recipeServings: 4,
+      recipeYieldQuantity: 4,
+      recipeYield: "personnes",
+    })
+    expect(getRecipeServings(recipe)).toBe(4)
+  })
+
+  it("retombe sur recipeYieldQuantity si recipeServings est absent", () => {
+    const recipe = makeRecipe({ recipeYieldQuantity: 6, recipeYield: "parts" })
+    expect(getRecipeServings(recipe)).toBe(6)
+  })
+
+  it("retombe sur le nombre contenu dans recipeYield (recettes legacy)", () => {
+    const recipe = makeRecipe({ recipeYield: "4 personnes" })
+    expect(getRecipeServings(recipe)).toBe(4)
+  })
+
+  it("ignore les valeurs nulles ou négatives", () => {
+    expect(getRecipeServings(makeRecipe({ recipeServings: 0, recipeYield: "personnes" }))).toBeUndefined()
+    expect(getRecipeServings(makeRecipe({ recipeServings: -2 }))).toBeUndefined()
+    expect(getRecipeServings(makeRecipe())).toBeUndefined()
+    expect(getRecipeServings(undefined)).toBeUndefined()
+  })
+
+  it("arrondit les portions fractionnaires renvoyées par l'API", () => {
+    // L'API Mealie renvoie des floats (4.0). Une valeur fractionnaire ne doit
+    // pas produire un ratio bancal côté affichage.
+    expect(getRecipeServings(makeRecipe({ recipeServings: 4.0 }))).toBe(4)
+    expect(getRecipeServings(makeRecipe({ recipeServings: 2.5 }))).toBe(2.5)
+  })
+
+  it("ne casse pas après une sauvegarde Bonap (recipeYield vidé de ses chiffres)", () => {
+    // RecipeRepository.update retire le nombre de recipeYield à chaque save.
+    // Une recette éditée dans Bonap doit garder ses portions (issue #14).
+    const afterBonapSave = makeRecipe({
+      recipeServings: 4,
+      recipeYieldQuantity: 4,
+      recipeYield: "",
+    })
+    expect(getRecipeServings(afterBonapSave)).toBe(4)
+  })
+})
+
+describe("encodeServingsInText / decodeServingsFromText", () => {
+  it("encode et décode le nombre de portions dans la note", () => {
+    expect(encodeServingsInText(4, "ma note")).toBe("[s:4]ma note")
+    expect(decodeServingsFromText("[s:4]ma note")).toEqual({ servings: 4, note: "ma note" })
+  })
+
+  it("laisse la note intacte sans préfixe", () => {
+    expect(encodeServingsInText(undefined, "ma note")).toBe("ma note")
+    expect(decodeServingsFromText("ma note")).toEqual({ servings: undefined, note: "ma note" })
+  })
+})
+
+describe("formatQuantity", () => {
+  it("arrondit à une décimale et supprime le .0", () => {
+    expect(formatQuantity(4)).toBe("4")
+    expect(formatQuantity(4.05)).toBe("4.1")
+    expect(formatQuantity(2.5)).toBe("2.5")
+  })
+})

--- a/src/shared/utils/servings.ts
+++ b/src/shared/utils/servings.ts
@@ -1,8 +1,31 @@
+import type { MealieRecipe } from "../types/mealie.ts"
+
 /** Parse "4", "4 personnes", "pour 4", "4-6 personnes" → first number found */
 export function parseServings(recipeYield?: string): number | undefined {
   if (!recipeYield) return undefined
   const m = recipeYield.match(/\d+/)
   return m ? parseInt(m[0], 10) : undefined
+}
+
+/**
+ * Reads a recipe's base servings count.
+ *
+ * Mealie >= 2 stores the number in `recipeServings` (mirrored in
+ * `recipeYieldQuantity`) and keeps `recipeYield` as a plain unit label
+ * ("personnes", "parts"…). Reading the number out of `recipeYield` therefore
+ * silently disables the whole servings system — and Bonap's own save strips
+ * digits from `recipeYield`, so an edited recipe would lose its portions.
+ * The `recipeYield` parse is kept last as a fallback for recipes created
+ * before Mealie split the fields.
+ */
+export function getRecipeServings(recipe?: MealieRecipe): number | undefined {
+  if (!recipe) return undefined
+  const candidates = [recipe.recipeServings, recipe.recipeYieldQuantity]
+  for (const value of candidates) {
+    if (typeof value === "number" && value > 0) return value
+  }
+  const legacy = parseServings(recipe.recipeYield)
+  return legacy && legacy > 0 ? legacy : undefined
 }
 
 /**


### PR DESCRIPTION
## Problème

Le système de portions existe déjà dans Bonap, mais il est débranché à la lecture : Bonap cherche le nombre de portions **dans le mauvais champ Mealie**.

Depuis Mealie 2, le nombre est stocké dans `recipeServings` (recopié dans `recipeYieldQuantity`), et `recipeYield` n'est plus qu'un **libellé d'unité**. Vérifié sur une instance neuve v3.22.0 :

```jsonc
// PATCH { "recipeServings": 4, "recipeYieldQuantity": 4, "recipeYield": "personnes" }
// puis GET /api/recipes/:slug →
{
  "recipeServings":      4.0,          // ← le nombre est ici
  "recipeYieldQuantity": 4.0,
  "recipeYield":         "personnes"   // ← et Bonap lisait ça
}
```

Or `parseServings()` extrait le premier chiffre de `recipeYield`. Sur `"personnes"` il n'y en a aucun → `undefined` → le système de portions se désactive en silence et l'UI affiche « Définir les portions dans la recette ».

C'est exactement le contournement décrit dans #14 : écrire `4 personne` dans le champ **Unité** de Mealie remet un chiffre dans `recipeYield`, et tout remarche.

Second effet, plus vicieux : `RecipeRepository.update()` **retire les chiffres** de `recipeYield` à chaque sauvegarde (ligne 189, comportement volontaire et correct côté écriture). Donc dès qu'une recette est éditée dans Bonap, elle perd ses portions à la lecture suivante — ce qui correspond au « ça ne fonctionne qu'une seule fois, si on replanifie derrière ça ne marche plus » rapporté dans #14.

Le fichier se contredisait d'ailleurs : `RecipeDetailPage.tsx:100` lisait bien `recipe.recipeServings` pour le formulaire, alors que la ligne 445 lisait `parseServings(recipe.recipeYield)` pour le mode cuisine.

## Correctif

Ajout de `getRecipeServings(recipe)` dans `shared/utils/servings.ts`, avec un ordre de priorité explicite :

1. `recipeServings` (Mealie ≥ 2)
2. `recipeYieldQuantity` (miroir)
3. `parseServings(recipeYield)` — **repli conservé** pour les recettes antérieures à la séparation des champs côté Mealie, afin de ne casser aucune installation existante

Le helper est branché sur les 7 sites d'appel qui reçoivent une recette (planning, mode cuisine, modale détail, planificateur équilibré, ajout au panier). `parseServings` reste utilisé pour le champ de formulaire, qui est réellement une chaîne numérique.

Les deux initialisations de formulaire qui lisaient `recipe.recipeServings` seul passent aussi par le helper : une recette legacy affiche désormais ses portions dans le champ d'édition, et la sauvegarde la migre naturellement vers `recipeServings`.

## Tests

- **`servings.test.ts`** (nouveau, 11 cas) : priorité des champs, repli legacy, valeurs nulles/négatives, et le cas « après sauvegarde Bonap » (`recipeYield` vidé de ses chiffres).
- **3 e2e** dans `planning.spec.ts` : format Mealie v2+, format legacy, et absence du message « Définir les portions ».
- **Fixtures e2e** alignées sur ce que renvoie une vraie instance v3.22.0 — elles ne contenaient aucun champ de rendement, ce qui est la raison pour laquelle le bug passait entre les mailles. Une recette (Salade niçoise) est volontairement laissée au format legacy pour couvrir le repli.

Vérification que les tests attrapent bien la régression : en retirant les changements de `src/`, 2 des 3 nouveaux e2e échouent, et le test legacy continue de passer.

Suite complète en local : `lint` ✅ · `typecheck` ✅ · `build` ✅ · `vitest` 107/107 ✅ · `playwright` 79/79 ✅

## Portée

Volontairement limité à la **lecture** des portions, qui est la cause racine commune à #14 et #39. Deux points distincts restent ouverts dans #14, que je peux traiter dans des PR séparées si ça t'intéresse :

- le ratio de portions n'atteint jamais la liste de courses — `PlanningPage` calcule bien `servingsRatio`, mais `useAddRecipesToCart` ne le transmet pas à `AddRecipesToListUseCase` ;
- quantités et unités perdues à l'ajout au panier (`AddRecipesToListUseCase` réduit chaque ingrédient à son nom), ce qui explique aussi les libellés vides de #98.

Dis-moi si tu préfères une autre découpe, ou si tu veux que je regroupe.

Refs #14, #39
