### PR TITLE
fix(shopping): afficher les unités de mesure dans la liste de courses

### DIFF
--- a/e2e/fixtures/mealie.ts
+++ b/e2e/fixtures/mealie.ts
@@ -168,6 +168,9 @@ export const SHOPPING_LIST_BONAP_RESPONSE = {
   id: "list-bonap",
   name: "Bonap",
   listItems: [
+    // Mealie renvoie `unit` et `food` comme objets imbriqués, pas comme
+    // champs plats (vérifié sur une instance v3.22.0) — c'est cette forme
+    // que lit ShoppingRepository.mapItem().
     {
       id: "item1",
       shoppingListId: "list-bonap",
@@ -176,10 +179,8 @@ export const SHOPPING_LIST_BONAP_RESPONSE = {
       isFood: true,
       note: "farine",
       quantity: 500,
-      unitId: "u1",
-      unitName: "g",
-      foodId: "f1",
-      foodName: "farine",
+      unit: { id: "u1", name: "gramme", abbreviation: "g", useAbbreviation: true },
+      food: { id: "f1", name: "farine" },
       label: { id: "label1", name: "Féculents", color: "#ff0000" },
       display: "500 g farine",
     },
@@ -191,12 +192,24 @@ export const SHOPPING_LIST_BONAP_RESPONSE = {
       isFood: true,
       note: "mozzarella",
       quantity: 200,
-      unitId: "u3",
-      unitName: "g",
-      foodId: "f3",
-      foodName: "mozzarella",
+      unit: { id: "u1", name: "gramme", abbreviation: "g", useAbbreviation: true },
+      food: { id: "f3", name: "mozzarella" },
       label: { id: "label2", name: "Produits laitiers", color: "#00ff00" },
       display: "200 g mozzarella",
+    },
+    // Unité sans abréviation, au pluriel — le cas « 11 gousses d'ail » de #98.
+    {
+      id: "item3",
+      shoppingListId: "list-bonap",
+      checked: false,
+      position: 2,
+      isFood: true,
+      note: "ail",
+      quantity: 11,
+      unit: { id: "u5", name: "gousse", pluralName: "gousses", useAbbreviation: false },
+      food: { id: "f6", name: "ail" },
+      label: { id: "label1", name: "Féculents", color: "#ff0000" },
+      display: "11 gousses ail",
     },
   ],
   // Format attendu par ShoppingRepository.getItems() : { label: { id, name, color } }

--- a/e2e/shopping.spec.ts
+++ b/e2e/shopping.spec.ts
@@ -81,7 +81,8 @@ test.describe("Liste de courses", () => {
       await page.goto("/shopping")
       await expect(page.getByText("mozzarella")).toBeVisible({ timeout: 8000 })
 
-      const checkedItem = page.locator(".line-through")
+      // .first() car le nom ET l'unité de l'article sont barrés
+      const checkedItem = page.locator(".line-through").first()
       await expect(checkedItem).toBeVisible()
     })
   })
@@ -240,8 +241,30 @@ test.describe("Liste de courses", () => {
 
       await page.goto("/shopping")
       await expect(page.getByRole("heading", { name: "Liste de courses" })).toBeVisible()
-      // Un item coché est affiché avec line-through
-      await expect(page.locator(".line-through")).toBeVisible({ timeout: 8000 })
+      // Un item coché est affiché avec line-through (nom + unité)
+      await expect(page.locator(".line-through").first()).toBeVisible({ timeout: 8000 })
+    })
+  })
+
+  test.describe("Unités de mesure (issue #98)", () => {
+    test("affiche l'unité à côté de la quantité", async ({ page }) => {
+      await page.goto("/shopping")
+      await expect(page.getByText("farine")).toBeVisible({ timeout: 8000 })
+
+      // 500 g de farine : la quantité seule ne suffit pas, l'unité doit suivre.
+      const farineRow = page.locator("li").filter({ hasText: "farine" }).first()
+      await expect(farineRow.getByText("500", { exact: true })).toBeVisible()
+      await expect(farineRow.getByText("g", { exact: true })).toBeVisible()
+    })
+
+    test("utilise le pluriel des unités sans abréviation", async ({ page }) => {
+      await page.goto("/shopping")
+      await expect(page.getByText("ail")).toBeVisible({ timeout: 8000 })
+
+      // Cas rapporté dans #98 : « 11 gousses d'ail ».
+      const ailRow = page.locator("li").filter({ hasText: "ail" }).first()
+      await expect(ailRow.getByText("11", { exact: true })).toBeVisible()
+      await expect(ailRow.getByText("gousses", { exact: true })).toBeVisible()
     })
   })
 })

--- a/src/domain/shopping/entities/ShoppingItem.ts
+++ b/src/domain/shopping/entities/ShoppingItem.ts
@@ -4,6 +4,16 @@ export interface ShoppingLabel {
   color?: string
 }
 
+/** Unit of measure attached to an item, with the fields Mealie uses to render it. */
+export interface ShoppingUnit {
+  id: string
+  name: string
+  pluralName?: string
+  abbreviation?: string
+  pluralAbbreviation?: string
+  useAbbreviation?: boolean
+}
+
 export interface ShoppingItem {
   id: string
   shoppingListId: string
@@ -12,7 +22,7 @@ export interface ShoppingItem {
   isFood: boolean
   note?: string
   quantity?: number
-  unitName?: string
+  unit?: ShoppingUnit
   foodName?: string
   label?: ShoppingLabel
   /** Display text (computed by Mealie or raw note) */

--- a/src/infrastructure/mealie/repositories/ShoppingRepository.test.ts
+++ b/src/infrastructure/mealie/repositories/ShoppingRepository.test.ts
@@ -32,7 +32,7 @@ function rawItem(overrides = {}) {
     isFood: true,
     note: "Lait",
     quantity: 2,
-    unit: { name: "L" },
+    unit: { id: "u-l", name: "litre", abbreviation: "L", useAbbreviation: true },
     food: { name: "lait" },
     label: { id: "label-1", name: "Produits laitiers", color: "#aaa" },
     display: "2 L lait",
@@ -99,7 +99,9 @@ describe("ShoppingRepository", () => {
       expect(items).toHaveLength(1)
       const item = items[0]
       expect(item.foodName).toBe("lait")
-      expect(item.unitName).toBe("L")
+      expect(item.unit?.name).toBe("litre")
+      expect(item.unit?.abbreviation).toBe("L")
+      expect(item.unit?.useAbbreviation).toBe(true)
       expect(item.label?.name).toBe("Produits laitiers")
       expect(item.source).toBe("mealie")
       expect(labels).toHaveLength(1)

--- a/src/infrastructure/mealie/repositories/ShoppingRepository.ts
+++ b/src/infrastructure/mealie/repositories/ShoppingRepository.ts
@@ -24,7 +24,16 @@ function mapItem(raw: MealieShoppingItem, recipeById: Map<string, string> = new 
     isFood: raw.isFood,
     note: raw.note,
     quantity: raw.quantity,
-    unitName: raw.unit?.name,
+    unit: raw.unit
+      ? {
+          id: raw.unit.id,
+          name: raw.unit.name,
+          pluralName: raw.unit.pluralName ?? undefined,
+          abbreviation: raw.unit.abbreviation ?? undefined,
+          pluralAbbreviation: raw.unit.pluralAbbreviation ?? undefined,
+          useAbbreviation: raw.unit.useAbbreviation,
+        }
+      : undefined,
     foodName: raw.food?.name,
     label: raw.label
       ? { id: raw.label.id, name: raw.label.name, color: raw.label.color }

--- a/src/presentation/components/shopping/MealieItemRow.tsx
+++ b/src/presentation/components/shopping/MealieItemRow.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react"
 import { Minus, Plus, Trash2, Check } from "lucide-react"
 import type { ShoppingItem, ShoppingLabel } from "../../../domain/shopping/entities/ShoppingItem.ts"
 import { cn } from "../../../lib/utils.ts"
+import { formatUnit } from "../../../shared/utils/shoppingQuantity.ts"
 import { LabelDropdown } from "./LabelDropdown.tsx"
 
 interface MealieItemRowProps {
@@ -22,6 +23,8 @@ export function MealieItemRow({ item, labels, onToggle, onDelete, onUpdateQuanti
   const recipeNamesFromNote = recipeSuffix ? [recipeSuffix] : []
   const allRecipeNames = item.recipeNames?.length ? item.recipeNames : recipeNamesFromNote
   const qty = item.quantity ?? 0
+  // The stepper badge stays purely numeric, so the unit is rendered beside it.
+  const unitLabel = qty > 0 ? formatUnit(qty, item.unit) : ""
 
   const [editing, setEditing] = useState(false)
   const [editValue, setEditValue] = useState(displayName)
@@ -90,6 +93,17 @@ export function MealieItemRow({ item, labels, onToggle, onDelete, onUpdateQuanti
           <Plus className="h-3 w-3" />
         </button>
       </div>
+
+      {unitLabel && (
+        <span
+          className={cn(
+            "shrink-0 text-xs text-muted-foreground tabular-nums",
+            item.checked && "line-through opacity-40",
+          )}
+        >
+          {unitLabel}
+        </span>
+      )}
 
       {editing ? (
         <input

--- a/src/presentation/components/shopping/buildPrintHtml.ts
+++ b/src/presentation/components/shopping/buildPrintHtml.ts
@@ -1,4 +1,5 @@
 import type { ShoppingItem, ShoppingLabel } from "../../../domain/shopping/entities/ShoppingItem.ts"
+import { formatItemQuantity } from "../../../shared/utils/shoppingQuantity.ts"
 import { itemSortKey } from "./itemSortKey.ts"
 
 export function buildPrintHtml(items: ShoppingItem[], labels: ShoppingLabel[], date: string): string {
@@ -33,7 +34,16 @@ export function buildPrintHtml(items: ShoppingItem[], labels: ShoppingLabel[], d
         : ""
       const itemsHtml = group.items.map((item) => {
         const name = escape(item.foodName ?? (item.note?.split(" — ")[0]) ?? "Article")
-        const qty = item.quantity && item.quantity > 1 ? `<span style="font-size:9pt;color:#888;margin-left:8px">×${item.quantity}</span>` : ""
+        // With a unit, print the full measure ("700 g"); without one, keep the
+        // bare "×N" marker and only when it carries information.
+        const amount = item.unit
+          ? formatItemQuantity(item.quantity, item.unit)
+          : item.quantity && item.quantity > 1
+            ? `×${item.quantity}`
+            : ""
+        const qty = amount
+          ? `<span style="font-size:9pt;color:#888;margin-left:8px">${escape(amount)}</span>`
+          : ""
         const style = faded ? "opacity:0.35;text-decoration:line-through;color:#aaa" : ""
         return `<div style="display:flex;align-items:center;padding:3px 0;border-bottom:1px solid #eee;${style}">
           <span style="display:inline-block;width:12px;height:12px;border:1.5px solid ${faded ? "#bbb" : "#555"};margin-right:8px;flex-shrink:0"></span>

--- a/src/shared/types/mealie.ts
+++ b/src/shared/types/mealie.ts
@@ -197,6 +197,15 @@ export interface MealieShoppingItemRecipeRef {
   recipe?: { id: string; name: string; slug: string }
 }
 
+export interface MealieShoppingItemUnit {
+  id: string
+  name: string
+  pluralName?: string | null
+  abbreviation?: string | null
+  pluralAbbreviation?: string | null
+  useAbbreviation?: boolean
+}
+
 export interface MealieShoppingItem {
   id: string
   shoppingListId: string
@@ -205,7 +214,7 @@ export interface MealieShoppingItem {
   isFood: boolean
   note?: string
   quantity?: number
-  unit?: { id: string; name: string }
+  unit?: MealieShoppingItemUnit
   food?: { id: string; name: string }
   label?: MealieShoppingLabel
   display?: string

--- a/src/shared/utils/shoppingQuantity.test.ts
+++ b/src/shared/utils/shoppingQuantity.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import { formatAmount, formatUnit, formatItemQuantity } from "./shoppingQuantity.ts"
+
+// Unités telles que renvoyées par une instance Mealie v3.22.0.
+const GRAMME = { name: "gramme", abbreviation: "g", useAbbreviation: true }
+const CUILLERE = { name: "cuillère à soupe", abbreviation: "c. à s.", useAbbreviation: true }
+const GOUSSE = { name: "gousse", pluralName: "gousses", useAbbreviation: false }
+const BOITE = { name: "boîte", abbreviation: undefined, useAbbreviation: false }
+
+describe("formatAmount", () => {
+  it("supprime les décimales inutiles", () => {
+    expect(formatAmount(700)).toBe("700")
+    expect(formatAmount(700.0)).toBe("700")
+  })
+
+  it("conserve les décimales utiles", () => {
+    expect(formatAmount(2.5)).toBe("2.5")
+    expect(formatAmount(0.25)).toBe("0.25")
+  })
+})
+
+describe("formatUnit", () => {
+  it("préfère l'abréviation quand l'unité est marquée useAbbreviation", () => {
+    expect(formatUnit(700, GRAMME)).toBe("g")
+    expect(formatUnit(3, CUILLERE)).toBe("c. à s.")
+  })
+
+  it("utilise le nom complet sinon", () => {
+    expect(formatUnit(1, BOITE)).toBe("boîte")
+  })
+
+  it("utilise le pluriel au-delà de un", () => {
+    expect(formatUnit(11, GOUSSE)).toBe("gousses")
+    expect(formatUnit(1, GOUSSE)).toBe("gousse")
+  })
+
+  it("retourne une chaîne vide sans unité", () => {
+    expect(formatUnit(3, undefined)).toBe("")
+  })
+})
+
+describe("formatItemQuantity", () => {
+  it("associe quantité et unité", () => {
+    expect(formatItemQuantity(700, GRAMME)).toBe("700 g")
+    // Cas rapporté dans #98 : « 3 C.A.S de sauce huître » affiché « 3 sauces huitres ».
+    expect(formatItemQuantity(3, CUILLERE)).toBe("3 c. à s.")
+    // Cas rapporté dans #98 : « 11 gousses d'ail ».
+    expect(formatItemQuantity(11, GOUSSE)).toBe("11 gousses")
+  })
+
+  it("affiche la quantité seule quand l'article n'a pas d'unité", () => {
+    expect(formatItemQuantity(3, undefined)).toBe("3")
+  })
+
+  it("n'affiche rien pour une quantité absente ou nulle", () => {
+    expect(formatItemQuantity(undefined, GRAMME)).toBe("")
+    expect(formatItemQuantity(0, GRAMME)).toBe("")
+  })
+})

--- a/src/shared/utils/shoppingQuantity.ts
+++ b/src/shared/utils/shoppingQuantity.ts
@@ -1,0 +1,43 @@
+/**
+ * Structural shape of a unit of measure. Kept structural so this helper stays
+ * free of any dependency on the shopping domain.
+ */
+interface QuantityUnit {
+  name: string
+  pluralName?: string
+  abbreviation?: string
+  pluralAbbreviation?: string
+  useAbbreviation?: boolean
+}
+
+/** Formats a number the way Mealie does: no trailing zeros on whole values. */
+export function formatAmount(quantity: number): string {
+  const rounded = Math.round(quantity * 100) / 100
+  return rounded % 1 === 0 ? String(Math.round(rounded)) : String(rounded)
+}
+
+/**
+ * Renders the unit label for a given quantity, following Mealie's own rules:
+ * the abbreviation wins when the unit is flagged `useAbbreviation`, and the
+ * plural form is used beyond one.
+ */
+export function formatUnit(quantity: number, unit?: QuantityUnit): string {
+  if (!unit) return ""
+  const plural = quantity > 1
+  if (unit.useAbbreviation && unit.abbreviation) {
+    return (plural && unit.pluralAbbreviation) || unit.abbreviation
+  }
+  return (plural && unit.pluralName) || unit.name
+}
+
+/**
+ * Formats a shopping item's quantity together with its unit — "700 g",
+ * "3 c. à s.", or just "3" when the item carries no unit.
+ * Returns an empty string when there is nothing meaningful to show.
+ */
+export function formatItemQuantity(quantity?: number, unit?: QuantityUnit): string {
+  if (quantity === undefined || quantity <= 0) return ""
+  const amount = formatAmount(quantity)
+  const label = formatUnit(quantity, unit)
+  return label ? `${amount} ${label}` : amount
+}


### PR DESCRIPTION
## Problème

Les articles de la liste de courses portent bien leur unité depuis l'API Mealie jusqu'à l'entité de domaine — puis la couche présentation la jette : ni la ligne d'article ni l'export impression ne lisent `unitName`.

Résultat, les deux cas rapportés dans #98 :

| Dans Mealie | Affiché par Bonap |
|---|---|
| 3 c. à s. de sauce huître | `3 sauce huître` |
| 11 gousses d'ail | `11 ail` |

C'est bien ce que décrit Pierre-Lavoine après ton correctif de mai : « c'est mieux mais il y a encore des choses étranges — je n'ai pas les unités ». Le champ était mappé, jamais rendu. Il l'était aussi à l'impression, d'où le « si je tente l'impression c'est identique ».

## Correctif

Ajout de `formatUnit` / `formatItemQuantity`, qui suivent les règles de rendu de Mealie lui-même plutôt que d'afficher brutalement `unit.name` :

- l'abréviation l'emporte quand l'unité est marquée `useAbbreviation` (`gramme` → `g`)
- le pluriel est utilisé au-delà de 1 (`gousse` → `gousses`)

Le compteur de quantité reste purement numérique, puisque ses boutons `−` / `+` incrémentent ce nombre : l'unité est rendue **à côté** du badge, pas dedans.

Porter ces règles demande plus que le nom de l'unité, donc `ShoppingItem.unitName` devient un objet `unit` contenant les champs dont Mealie se sert pour l'afficher. Ce champ n'avait aucun autre lecteur dans le projet, la bascule est donc sans effet de bord.

## Pourquoi les tests ne voyaient rien

Les fixtures e2e de la liste de courses décrivaient les articles avec des champs **plats** (`unitName`, `unitId`, `foodName`, `foodId`). L'API Mealie ne renvoie jamais cette forme, et `mapItem()` ne la lit pas — il lit `raw.unit?.name` et `raw.food?.name`.

Autrement dit, dans tous les tests existants, chaque article avait silencieusement `unit: undefined` et `food: undefined`, et l'affichage retombait sur `note`. Le bug ne pouvait pas être attrapé. Les fixtures correspondent maintenant à une vraie réponse v3.22.0, avec un article en unité plurielle non abrégée pour couvrir le cas « 11 gousses ».

## Tests

- **`shoppingQuantity.test.ts`** (nouveau, 9 cas) : abréviation, pluriel, absence d'unité, quantité nulle.
- **2 e2e** dans `shopping.spec.ts` sur les cas exacts de l'issue — vérifiés rouges sans le correctif.
- **Vérifié aussi hors mocks** : sur une instance Mealie v3.22.0 réelle, liste remplie par l'API, l'interface affiche « 400 g farine », « 11 gousses ail ».

Suite complète : `lint` ✅ · `typecheck` ✅ · `build` ✅ · `vitest` 105/105 ✅ · `playwright` 78/78 ✅

## Deux points à signaler

**J'ai touché deux de tes assertions existantes.** Un article coché barre désormais son nom **et** son unité, donc `page.locator(".line-through")` matche légitimement deux éléments au lieu d'un. J'ai ajouté `.first()` — le motif que tu utilises déjà ailleurs dans ce fichier pour la même raison. L'intention des tests est inchangée, mais je préfère te le dire plutôt que de le glisser discrètement.

**Cette PR ne traite que l'affichage.** L'autre moitié de #98 — les articles ajoutés *depuis Bonap* qui perdent quantité, unité et étiquette — vient du chemin d'ingestion, dans `AddRecipesToListUseCase`. J'ai une piste solide là-dessus que je détaille dans #14 : Mealie expose un endpoint natif qui fait déjà tout ça. Je préfère avoir ton avis avant de toucher à ce chemin.

Indépendante de #148, mergeable dans n'importe quel ordre.

Refs #98, #14
