### PR TITLE
fix(bff): corriger la route du proxy Ollama, incompatible avec Express 4

### DIFF
--- a/ha-addon/bonap-bff.cjs
+++ b/ha-addon/bonap-bff.cjs
@@ -1639,15 +1639,20 @@ function isPrivateOrLocalUrl(rawUrl) {
   }
 }
 
-app.all('/ollama-proxy/*path', async (req, res) => {
+// Mounted with app.use() rather than a wildcard path: `/ollama-proxy/*path` is
+// Express 5 syntax, but this service ships with Express 4 (see bff-package.json),
+// where `*` compiles to `(.*)` and `path` stays a literal — so the pattern only
+// matched URLs ending in "path" and `/ollama-proxy/api/tags` fell through to a
+// 404. A mount path behaves identically on both majors, and `req.url` then holds
+// the remaining subpath, query string included.
+app.use('/ollama-proxy', async (req, res) => {
   const target = req.headers['x-ollama-target']
   if (typeof target !== 'string' || !isPrivateOrLocalUrl(target)) {
     return res
       .status(400)
       .json({ error: 'X-Ollama-Target manquant ou non autorisé (réseau local uniquement)' })
   }
-  const subpath = req.params['path'] ?? ''
-  const url = `${target.replace(/\/+$/, '')}/${subpath}`
+  const url = `${target.replace(/\/+$/, '')}${req.url}`
   try {
     const hasBody = req.method !== 'GET' && req.method !== 'HEAD'
     const upstreamRes = await fetch(url, {


### PR DESCRIPTION
## Cause

@Turijo avait bien identifié l'endroit dans #131 : « le problème semble venir du proxy interne BonAp vers Ollama ». C'est exactement ça, et c'est une histoire de version d'Express.

La route est déclarée ainsi :

```js
app.all('/ollama-proxy/*path', …)
```

`/*path` est la syntaxe de joker nommé d'**Express 5**. Or le conteneur embarque **Express 4** (`ha-addon/bff-package.json` épingle `^4.21.2`). En Express 4, `*` est compilé en `(.*)` et `path` reste un segment **littéral** — le motif ne matche donc que les URL se terminant par « path ».

Reproduction sur Express 4.22 :

```
404  /ollama-proxy/api/tags     ->  Cannot GET /ollama-proxy/api/tags
404  /ollama-proxy/api/chat     ->  Cannot GET /ollama-proxy/api/chat
200  /ollama-proxy/xxxpath      ->  {"params":{"0":"xxx"}}
```

La troisième ligne confirme les deux points : « path » est bien traité comme du texte, et même quand le motif matche, `req.params['path']` est `undefined` — Express 4 expose les groupes positionnels dans `req.params[0]`.

`/ollama-proxy/api/tags` n'était donc jamais routée et tombait sur le gestionnaire par défaut d'Express, d'où le `Cannot GET /ollama-proxy/api/tags` du rapport, avec l'en-tête `X-Powered-By: Express` qui pointait déjà vers le BFF.

## Pourquoi ça passe inaperçu en local

La racine du dépôt épingle Express **5** (`package.json`), et `require('express')` depuis `ha-addon/` remonte la chaîne `node_modules` jusqu'à la racine du projet. Sur une machine de dev, la route est donc servie par Express 5 et **fonctionne**. Elle ne casse que dans l'image construite, où seul `bff-package.json` est installé.

Je suis tombé dans le piège pendant l'analyse : mon premier harnais de test croyait charger Express 4 via `NODE_PATH`, alors qu'il résolvait Express 5 depuis la racine. Le symptôme était un chemin transmis en `/api,tags` — la virgule d'un tableau converti en chaîne, `req.params['path']` étant un tableau en Express 5.

## Correctif

Montage de la route plutôt que motif joker :

```js
app.use('/ollama-proxy', …)
```

Un chemin de montage se comporte **identiquement en Express 4 et 5**, donc la route ne dépend plus de la version installée — le mode de panne disparaît au lieu d'être simplement contourné. `req.url` porte alors le sous-chemin restant, chaîne de requête comprise, que la version à base de paramètre perdait.

8 lignes ajoutées, 3 supprimées, un seul fichier. Aucun changement côté front : le contrat (`X-Ollama-Target` + sous-chemin) était déjà correct, seule la route serveur manquait à l'appel.

## Vérification

En exécutant le vrai `bonap-bff.cjs` contre un Ollama bouchonné, avec Express 4 réellement résolu :

| | Avant | Après |
|---|---|---|
| `GET /api/tags` (récupérer les modèles) | 404, rien n'atteint Ollama | **200**, modèles renvoyés |
| `POST /api/chat` (tester la connexion) | 404 | **200** |
| Garde-fou réseau privé (cible publique) | — | **400**, toujours actif |

Même résultat vérifié sur Express 5, pour que la route reste correcte si le conteneur monte de version un jour.

`lint` ✅ · `typecheck` ✅ · `vitest` 96/96 ✅

## Note

Je n'ai pas ajouté de test automatisé : le BFF appelle `app.listen()` au chargement et n'a pas d'infrastructure de test, et reproduire fidèlement l'écart de version demanderait d'installer Express 4 en dépendance de dev à la racine. Le correctif étant valable sur les deux majeures, il n'y a plus de comportement dépendant de la version à surveiller. J'ai aussi vérifié qu'aucune autre route des deux serveurs n'utilise cette syntaxe joker.

Je n'ai pas d'instance Ollama sous la main pour rejouer le scénario complet de @Turijo — un retour de sa part serait utile pour confirmer.

Fixes #131
