### PR TITLE
feat(settings): choisir la page d'accueil de Bonap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Auth `Authorization: Bearer <VITE_MEALIE_TOKEN>`. Erreurs 401/404/5xx mappées. 
 
 | Route | Page | Description |
 |-------|------|-------------|
-| `/` | → redirect `/recipes` | |
+| `/` | → redirect vers la page d'accueil choisie (`HomeRedirect`, défaut `/recipes`) | |
 | `/recipes` | `RecipesPage` | Grille de recettes avec filtres (search, catégories, tags, durée, saisons), scroll infini |
 | `/recipes/new` | `RecipeFormPage` | Formulaire création recette |
 | `/recipes/:slug/edit` | `RecipeFormPage` | Formulaire édition recette |
@@ -240,6 +240,7 @@ Auth `Authorization: Bearer <VITE_MEALIE_TOKEN>`. Erreurs 401/404/5xx mappées. 
 | `useAssistant()` | Chat assistant avec historique, tools, streaming |
 | `useTheme()` | Thème + couleur d'accent avec ThemeService |
 | `useSidebar()` | État ouvert/fermé sidebar (mobile) |
+| `useHomePage()` | Page d'accueil (route `/`) : `homePage` choisi, `resolved` réellement atteignable, `available` = destinations proposables |
 
 ---
 
@@ -303,6 +304,12 @@ Deux modes : `llmChat` (single-turn, SuggestionsPage) et `sendAssistantMessage` 
 - **Nommage** : PascalCase composants/classes, camelCase utils/hooks. Use cases `<Verbe><Nom>UseCase.ts`. Hooks `use<Nom>.ts` (préfixe `use` obligatoire). Named exports partout (sauf `App.tsx`/`main.tsx`).
 - **État** : `useState`/`useCallback` + optimistic updates (pattern `useShopping.toggleItem` — flip immédiat, rollback si erreur). Pas de store global.
 - **Scroll infini** : `useRecipesInfinite` avec `loadingRef` (anti double-fetch) + `filtersKey` sérialisé (arrays triés) pour reset stable.
+
+## 8bis. Navigation
+
+`shared/constants/navigation.ts` (`NAV_ROUTES` + `visibleNavRoutes`) est la source unique des destinations principales — sans icône, pour rester lisible depuis l'infrastructure. `presentation/components/navItems.ts` y associe les icônes lucide (`visibleNavItems`). Sidebar et sélecteur de page d'accueil consomment ce module : ajouter une entrée de navigation se fait à un seul endroit.
+
+**Page d'accueil** (issue #158) : la route `/` redirige vers la préférence enregistrée (`HomePageService`, localStorage `bonap_home_page`, synchronisée serveur via `SERVER_SETTINGS_KEYS`). Réglable dans Paramètres → Apparence. Une valeur hors `NAV_ROUTES` ou pointant vers Suggestions IA sans fournisseur configuré retombe sur `/recipes`.
 
 ## 9. Thème
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { SuggestionsPage } from './presentation/pages/SuggestionsPage.tsx'
 import { ExploreRecipesPage } from './presentation/pages/ExploreRecipesPage.tsx'
 import { NutritionMappingPage } from './presentation/pages/NutritionMappingPage.tsx'
 import { KioskPage } from './presentation/pages/KioskPage.tsx'
+import { useHomePage } from './presentation/hooks/useHomePage.ts'
 
 const STORAGE_KEYS = {
   MEALIE_URL: 'bonap-mealie-url',
@@ -28,6 +29,12 @@ function ProtectedRoute() {
   return <Outlet />
 }
 
+/** Redirige `/` vers la page d'accueil choisie dans les paramètres. */
+function HomeRedirect() {
+  const { resolved } = useHomePage()
+  return <Navigate to={resolved} replace />
+}
+
 function App() {
   return (
     <Routes>
@@ -36,7 +43,7 @@ function App() {
       <Route path="kiosk-vertical" element={<KioskPage orientation="vertical" />} />
       <Route element={isProtectedRoute ? <ProtectedRoute /> : <Outlet />}>
         <Route element={<Layout />}>
-          <Route index element={<Navigate to="/recipes" replace />} />
+          <Route index element={<HomeRedirect />} />
           <Route path="recipes" element={<RecipesPage />} />
           <Route path="recipes/new" element={<RecipeFormPage />} />
           <Route path="recipes/:slug" element={<RecipeDetailPage />} />

--- a/src/infrastructure/settings/HomePageService.test.ts
+++ b/src/infrastructure/settings/HomePageService.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { homePageService, DEFAULT_HOME_PAGE, HOME_PAGE_ROUTES } from "./HomePageService.ts"
+
+describe("homePageService", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("retourne la page recettes par défaut", () => {
+    expect(homePageService.load()).toBe(DEFAULT_HOME_PAGE)
+  })
+
+  it("relit la page enregistrée", () => {
+    homePageService.save("/planning")
+    expect(homePageService.load()).toBe("/planning")
+  })
+
+  it("ignore une route inconnue et retombe sur la valeur par défaut", () => {
+    homePageService.save("/nimportequoi")
+    expect(homePageService.load()).toBe(DEFAULT_HOME_PAGE)
+  })
+
+  it("ignore une valeur corrompue déjà présente dans localStorage", () => {
+    localStorage.setItem("bonap_home_page", "/route-supprimee")
+    expect(homePageService.load()).toBe(DEFAULT_HOME_PAGE)
+  })
+
+  it("accepte toutes les entrées de navigation", () => {
+    for (const route of HOME_PAGE_ROUTES) {
+      homePageService.save(route)
+      expect(homePageService.load()).toBe(route)
+    }
+  })
+})

--- a/src/infrastructure/settings/HomePageService.ts
+++ b/src/infrastructure/settings/HomePageService.ts
@@ -1,0 +1,37 @@
+import { saveSettingToServer } from "./ServerSettingsService.ts"
+import { NAV_ROUTES } from "../../shared/constants/navigation.ts"
+
+const KEY = "bonap_home_page"
+
+/** Destination historique de la route `/` — reste le repli si rien n'est choisi. */
+export const DEFAULT_HOME_PAGE = "/recipes"
+
+/** Routes proposables comme page d'accueil (les entrées de navigation principales). */
+export const HOME_PAGE_ROUTES = NAV_ROUTES.map((route) => route.to)
+
+export const homePageService = {
+  /**
+   * Route d'accueil enregistrée. Retombe sur `/recipes` si la valeur stockée
+   * ne correspond plus à une entrée de navigation (route retirée, données
+   * corrompues, préférence synchronisée depuis une version plus récente).
+   */
+  load(): string {
+    try {
+      const raw = localStorage.getItem(KEY)
+      if (raw && HOME_PAGE_ROUTES.includes(raw)) return raw
+    } catch {
+      /* localStorage indisponible */
+    }
+    return DEFAULT_HOME_PAGE
+  },
+
+  save(route: string): void {
+    const value = HOME_PAGE_ROUTES.includes(route) ? route : DEFAULT_HOME_PAGE
+    try {
+      localStorage.setItem(KEY, value)
+    } catch {
+      /* localStorage indisponible */
+    }
+    saveSettingToServer(KEY, value)
+  },
+}

--- a/src/infrastructure/settings/ServerSettingsService.ts
+++ b/src/infrastructure/settings/ServerSettingsService.ts
@@ -19,6 +19,7 @@ export const SERVER_SETTINGS_KEYS = [
   'bonap.familySize',
   'bonap_planning_prefs',
   'bonap.featureFlags',
+  'bonap_home_page',
 ] as const
 
 export type ServerSettingsKey = (typeof SERVER_SETTINGS_KEYS)[number]

--- a/src/presentation/components/Sidebar.tsx
+++ b/src/presentation/components/Sidebar.tsx
@@ -1,21 +1,11 @@
 import { NavLink } from "react-router-dom"
-import { UtensilsCrossed, CalendarDays, BarChart2, ShoppingCart, ExternalLink, Settings, Sparkles, Globe } from "lucide-react"
+import { ExternalLink, Settings } from "lucide-react"
 import { cn } from "../../lib/utils.ts"
 import { getEnv, getIngressBasename } from "../../shared/utils/env.ts"
 import { llmConfigService } from "../../infrastructure/llm/LLMConfigService.ts"
+import { visibleNavItems } from "./navItems.ts"
 
-const isAIEnabled = llmConfigService.isConfigured()
-
-const navItems = [
-  { to: "/planning", label: "Planning", icon: CalendarDays },
-  { to: "/shopping", label: "Courses", icon: ShoppingCart },
-  { to: "/recipes", label: "Recettes", icon: UtensilsCrossed },
-  ...(isAIEnabled
-    ? [{ to: "/suggestions", label: "Suggestions IA", icon: Sparkles }]
-    : []),
-  { to: "/explore", label: "Explorer", icon: Globe },
-  { to: "/stats", label: "Statistiques", icon: BarChart2 },
-]
+const navItems = visibleNavItems(llmConfigService.isConfigured())
 
 interface SidebarProps {
   collapsed: boolean

--- a/src/presentation/components/navItems.ts
+++ b/src/presentation/components/navItems.ts
@@ -1,0 +1,29 @@
+import { UtensilsCrossed, CalendarDays, BarChart2, ShoppingCart, Sparkles, Globe } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+import { visibleNavRoutes } from "../../shared/constants/navigation.ts"
+import type { NavRoute } from "../../shared/constants/navigation.ts"
+
+export interface NavItem extends NavRoute {
+  icon: LucideIcon
+}
+
+const ICONS: Record<string, LucideIcon> = {
+  "/planning": CalendarDays,
+  "/shopping": ShoppingCart,
+  "/recipes": UtensilsCrossed,
+  "/suggestions": Sparkles,
+  "/explore": Globe,
+  "/stats": BarChart2,
+}
+
+/**
+ * Entrées de navigation affichables, icône comprise.
+ * Partagé entre la sidebar et le sélecteur de page d'accueil des paramètres,
+ * pour que les deux listes ne puissent pas diverger.
+ */
+export function visibleNavItems(isAIEnabled: boolean): NavItem[] {
+  return visibleNavRoutes(isAIEnabled).map((route) => ({
+    ...route,
+    icon: ICONS[route.to] ?? UtensilsCrossed,
+  }))
+}

--- a/src/presentation/hooks/useHomePage.ts
+++ b/src/presentation/hooks/useHomePage.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from "react"
+import { homePageService, DEFAULT_HOME_PAGE } from "../../infrastructure/settings/HomePageService.ts"
+import { llmConfigService } from "../../infrastructure/llm/LLMConfigService.ts"
+import { visibleNavItems } from "../components/navItems.ts"
+
+/**
+ * Page sur laquelle atterrir en ouvrant Bonap (route `/`).
+ *
+ * `resolved` est la route effectivement utilisable : si la page choisie n'est
+ * plus accessible (Suggestions IA sans fournisseur configuré), on retombe sur
+ * la destination par défaut plutôt que d'ouvrir une page vide.
+ */
+export function useHomePage() {
+  const [homePage, setHomePageState] = useState(() => homePageService.load())
+
+  const setHomePage = useCallback((route: string) => {
+    homePageService.save(route)
+    setHomePageState(homePageService.load())
+  }, [])
+
+  const available = visibleNavItems(llmConfigService.isConfigured())
+  const resolved = available.some((item) => item.to === homePage) ? homePage : DEFAULT_HOME_PAGE
+
+  return { homePage, setHomePage, resolved, available }
+}

--- a/src/presentation/pages/SettingsPage.tsx
+++ b/src/presentation/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { usePlanningPreferences } from "../hooks/usePlanningPreferences.ts"
 import { useFamilySize } from "../hooks/useFamilySize.ts"
 import { useFeatureFlags } from "../hooks/useFeatureFlags.ts"
 import { useDefaultHabituels } from "../hooks/useDefaultHabituels.ts"
+import { useHomePage } from "../hooks/useHomePage.ts"
 import { ACCENT_COLORS } from "../../infrastructure/theme/ThemeService.ts"
 import type { Theme } from "../../infrastructure/theme/ThemeService.ts"
 import { cn } from "../../lib/utils.ts"
@@ -124,6 +125,7 @@ export function SettingsPage() {
   const { familySize, setFamilySize } = useFamilySize()
   const { flags, setFlag } = useFeatureFlags()
   const { enabled: defaultHabituelsEnabled, toggle: toggleDefaultHabituels } = useDefaultHabituels()
+  const { homePage, setHomePage, available: homePageOptions } = useHomePage()
   const navigate = useNavigate()
   const [config, setConfig] = useState<LLMConfig>(() => llmConfigService.load())
   const envFields = getLLMEnvFields()
@@ -228,7 +230,7 @@ export function SettingsPage() {
         icon={<Palette className="h-4 w-4 text-primary" />}
         iconBg="bg-primary/8"
         title="Apparence"
-        subtitle="Thème et couleur d'accent"
+        subtitle="Thème, couleur d'accent et page d'accueil"
       >
         <div className="space-y-2.5">
           <Label>Thème</Label>
@@ -283,6 +285,35 @@ export function SettingsPage() {
                 {accentColor.id === color.id && (
                   <Check className="absolute inset-0 m-auto h-4 w-4 text-white drop-shadow" />
                 )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-2.5">
+          <div>
+            <Label>Page d'accueil</Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Page affichée à l'ouverture de Bonap
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {homePageOptions.map(({ to, label, icon: Icon }) => (
+              <button
+                key={to}
+                type="button"
+                onClick={() => setHomePage(to)}
+                aria-pressed={homePage === to}
+                className={cn(
+                  'flex items-center gap-2 rounded-[var(--radius-lg)] border px-3.5 py-2',
+                  'text-sm font-semibold transition-all duration-150',
+                  homePage === to
+                    ? 'border-primary bg-primary text-primary-foreground shadow-[0_1px_3px_oklch(0.58_0.175_38/0.25)]'
+                    : 'border-border bg-card text-foreground hover:bg-secondary',
+                )}
+              >
+                <Icon className="h-4 w-4" />
+                {label}
               </button>
             ))}
           </div>

--- a/src/shared/constants/navigation.ts
+++ b/src/shared/constants/navigation.ts
@@ -1,0 +1,27 @@
+/**
+ * Destinations de navigation principales, dans l'ordre d'affichage de la sidebar.
+ *
+ * Sans icône : ce module est aussi lu par l'infrastructure (validation de la
+ * page d'accueil enregistrée), qui ne doit rien savoir de la présentation. Les
+ * icônes sont associées dans `presentation/components/navItems.ts`.
+ */
+export interface NavRoute {
+  to: string
+  label: string
+  /** La destination n'est disponible que si un fournisseur LLM est configuré. */
+  requiresAI?: boolean
+}
+
+export const NAV_ROUTES: NavRoute[] = [
+  { to: "/planning", label: "Planning" },
+  { to: "/shopping", label: "Courses" },
+  { to: "/recipes", label: "Recettes" },
+  { to: "/suggestions", label: "Suggestions IA", requiresAI: true },
+  { to: "/explore", label: "Explorer" },
+  { to: "/stats", label: "Statistiques" },
+]
+
+/** Destinations visibles selon que l'IA est configurée ou non. */
+export function visibleNavRoutes(isAIEnabled: boolean): NavRoute[] {
+  return NAV_ROUTES.filter((route) => !route.requiresAI || isAIEnabled)
+}


### PR DESCRIPTION
Closes #158

## Problème

La route `/` redirigeait systématiquement vers `/recipes`. Aucun moyen d'atterrir sur le planning en ouvrant le dashboard Bonap.

## Solution

Un sélecteur **Page d'accueil** dans Paramètres → Apparence, proposant les mêmes destinations que la sidebar (Planning, Courses, Recettes, Suggestions IA, Explorer, Statistiques). La route `/` suit ce choix ; le défaut reste Recettes, donc rien ne change pour qui n'y touche pas.

## Détails d'implémentation

- **`shared/constants/navigation.ts`** — source unique des destinations principales (`NAV_ROUTES`, `visibleNavRoutes`). Volontairement sans icône : l'infrastructure la lit pour valider la préférence enregistrée et ne doit rien savoir de la présentation. `presentation/components/navItems.ts` y associe les icônes lucide. La sidebar dupliquait cette liste, elle la consomme maintenant — impossible que les deux divergent.
- **`HomePageService`** — localStorage `bonap_home_page`, ajouté à `SERVER_SETTINGS_KEYS` pour être synchronisé comme le thème et les préférences de planning (accès HA ingress vs domaine direct). Une valeur hors `NAV_ROUTES` (route retirée, données corrompues) retombe sur `/recipes`.
- **`useHomePage()`** — expose `resolved` en plus de `homePage` : si Suggestions IA a été choisie puis le fournisseur LLM retiré, `/` renvoie sur la page par défaut au lieu d'ouvrir une page inutilisable.

## Vérifications

- `npx tsc -b --noEmit` — OK
- `npx eslint src/` — OK
- `npx vitest run` — 142 tests, 13 fichiers (dont 5 nouveaux sur `HomePageService`)
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)