### PR TITLE
feat(cooking): afficher les ingrédients associés à chaque étape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,7 @@ npm run preview  # Prévisualisation prod
 - **updateItem shopping** : PUT peut retourner `null` (certaines versions Mealie) — fallback sur données envoyées.
 - **PUT shopping items = remplacement complet, pas un patch** : un payload sans `foodId` / `unitId` **détache l'aliment et l'unité** de l'article côté Mealie. Au rechargement, `food` et `unit` sont `null` : les articles issus de recettes (`isFood: true`, `note` vide) perdent leur nom et s'affichent « Article sans nom ». Toujours construire le payload via `toItemUpdate(item, listId, patch)` (`shared/utils/shoppingItemUpdate.ts`), jamais à la main. C'était la cause de la perte d'articles après le tri IA de la liste de courses (`useCategorizeItems` met à jour tous les articles non catégorisés d'un coup).
 - **Durées** : formulaire en minutes integer, API en ISO 8601 (`PT30M`). Conversion dans `RecipeRepository.minutesToIso()`. `formatDuration()` accepte les deux formats.
+- **PUT `/api/recipes/:slug` = remplacement complet** : `update()` repart de `current` et fusionne. Pour `recipeInstructions`, la fusion se fait par `id` — n'envoyer que `{ id, text }` effacerait `title` et surtout `ingredientReferences` (ingrédients associés à l'étape). Même famille de piège que le PUT shopping.
 - **resolveIngredients** : 2 appels API (foods + units) à chaque create/update. Aliments créés auto, unités non créées (unitId reste undefined → texte libre).
 - **Anthropic-only streaming + tool use** : les 8 autres providers ont fallback single-turn sans tools — documenté dans Settings.
 - **OpenCode Go/Zen** : pas de CORS header → proxy Vite/nginx (`/api/opencode-go`, `/api/opencode`), comme Ollama.
@@ -335,6 +336,10 @@ npm run preview  # Prévisualisation prod
 - La liste "Bonap" et "Habituels" sont auto-créées dans Mealie si elles n'existent pas
 - **Tri IA** (`useCategorizeItems`) : applique d'abord les labels connus du `FoodLabelStore`, puis un seul appel `llmChat` pour le reste. Chaque affectation passe par `updateItemLabel` → `toItemUpdate` (voir piège PUT ci-dessus).
 - **Habituels** : créés avec `isFood: true` et un `foodId` résolu (création à la volée si l'aliment n'existe pas dans Mealie). Évite l'enregistrement en simple texte (note) qui empêchait le typage.
+
+### Mode cuisine
+- **Ingrédients par étape** (issue #38) : Mealie relie une étape à ses ingrédients via `instruction.ingredientReferences[].referenceId` ↔ `ingredient.referenceId`. `ingredientsForInstruction()` (`shared/utils/instructionIngredients.ts`) fait la jointure ; `CookingMode` affiche l'encart « Pour cette étape » avec les quantités mises à l'échelle des portions. L'encart disparaît si la recette n'associe rien.
+- **L'association se crée dans Mealie**, pas dans Bonap — le formulaire Bonap ne l'édite pas, mais ne l'écrase plus (voir piège PUT recette).
 
 ### Portions / scaling
 - **Lecture** : toujours `getRecipeServings(recipe)`, jamais `parseServings(recipe.recipeYield)` — voir `shared/utils/servings.ts`. Le bug #14 venait précisément de cette confusion.

--- a/src/infrastructure/mealie/repositories/RecipeRepository.test.ts
+++ b/src/infrastructure/mealie/repositories/RecipeRepository.test.ts
@@ -260,4 +260,78 @@ describe("RecipeRepository", () => {
       expect(putBody.recipeYieldQuantity).toBe(4)
     })
   })
+
+  // ── update — préservation des étapes ────────────────────────────────────────
+
+  describe("update — recipeInstructions", () => {
+    const baseForm = {
+      name: "Test",
+      description: "",
+      prepTime: "0",
+      performTime: "0",
+      totalTime: "0",
+      seasons: [] as string[],
+      categories: [] as Array<{ id: string; name: string; slug: string }>,
+      tags: [] as Array<{ id: string; name: string; slug: string }>,
+      recipeIngredient: [],
+      recipeInstructions: [],
+    }
+
+    const current = {
+      id: "r1",
+      slug: "test",
+      name: "Test",
+      tags: [],
+      recipeInstructions: [
+        {
+          id: "step-1",
+          title: "Préparation",
+          text: "Mélanger",
+          ingredientReferences: [{ referenceId: "ref-1" }],
+        },
+      ],
+    }
+
+    beforeEach(() => {
+      client.get.mockImplementation((url: string) => {
+        if (url.includes("/organizers/tags")) return Promise.resolve({ items: [] })
+        return Promise.resolve(current)
+      })
+      client.put.mockResolvedValue({ id: "r1" })
+    })
+
+    it("préserve les ingrédients associés et le titre d'une étape existante", async () => {
+      await repo.update("test", {
+        ...baseForm,
+        recipeInstructions: [{ id: "step-1", text: "Mélanger longuement" }],
+      })
+      const putBody = client.put.mock.calls[0][1]
+      expect(putBody.recipeInstructions[0]).toMatchObject({
+        id: "step-1",
+        title: "Préparation",
+        text: "Mélanger longuement",
+        ingredientReferences: [{ referenceId: "ref-1" }],
+      })
+    })
+
+    it("génère un id pour une nouvelle étape, sans associations", async () => {
+      await repo.update("test", {
+        ...baseForm,
+        recipeInstructions: [{ text: "Enfourner" }],
+      })
+      const putBody = client.put.mock.calls[0][1]
+      expect(putBody.recipeInstructions[0].id).toBeTruthy()
+      expect(putBody.recipeInstructions[0].text).toBe("Enfourner")
+      expect(putBody.recipeInstructions[0].ingredientReferences).toBeUndefined()
+    })
+
+    it("ignore les étapes vides", async () => {
+      await repo.update("test", {
+        ...baseForm,
+        recipeInstructions: [{ id: "step-1", text: "Mélanger" }, { text: "   " }],
+      })
+      const putBody = client.put.mock.calls[0][1]
+      expect(putBody.recipeInstructions).toHaveLength(1)
+    })
+  })
 })

--- a/src/infrastructure/mealie/repositories/RecipeRepository.ts
+++ b/src/infrastructure/mealie/repositories/RecipeRepository.ts
@@ -195,12 +195,21 @@ export class RecipeRepository implements IRecipeRepository {
         return orig ? { ...orig, ...c } : c
       }),
       recipeIngredient: mappedIngredients,
+      // Fusion avec l'étape existante : le PUT remplace la recette entière, donc
+      // n'envoyer que { id, text } effacerait le titre et surtout les
+      // ingredientReferences (ingrédients associés à l'étape, affichés en mode cuisine).
       recipeInstructions: data.recipeInstructions
         .filter((step) => step.text.trim())
-        .map((step) => ({
-          id: step.id ?? generateId(),
-          text: step.text,
-        })),
+        .map((step) => {
+          const original = step.id
+            ? current.recipeInstructions?.find((s) => s.id === step.id)
+            : undefined
+          return {
+            ...(original ?? {}),
+            id: step.id ?? generateId(),
+            text: step.text,
+          }
+        }),
       tags: [...data.tags, ...seasonTags],
       extras: { ...(current.extras ?? {}), ...(data.extras ?? {}) },
     }

--- a/src/presentation/components/CookingMode.test.tsx
+++ b/src/presentation/components/CookingMode.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { MealieIngredient, MealieInstruction } from "../../shared/types/mealie.ts"
+import { CookingMode } from "./CookingMode.tsx"
+
+const ingredients: MealieIngredient[] = [
+  { referenceId: "ref-1", quantity: 250, unit: { name: "g" }, food: { name: "farine" } },
+  { referenceId: "ref-2", quantity: 3, food: { name: "œufs" } },
+  { referenceId: "ref-3", quantity: 50, unit: { name: "cl" }, food: { name: "lait" } },
+]
+
+const instructions: MealieInstruction[] = [
+  {
+    id: "step-1",
+    text: "Mélanger la farine et les œufs",
+    ingredientReferences: [{ referenceId: "ref-1" }, { referenceId: "ref-2" }],
+  },
+  { id: "step-2", text: "Cuire à la poêle" },
+]
+
+function renderCookingMode(props: Partial<Parameters<typeof CookingMode>[0]> = {}) {
+  return render(
+    <CookingMode
+      recipeName="Crêpes"
+      ingredients={ingredients}
+      instructions={instructions}
+      onClose={vi.fn()}
+      {...props}
+    />,
+  )
+}
+
+/** Passe de l'écran ingrédients à l'étape 1. */
+async function goToFirstStep(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Commencer" }))
+}
+
+describe("CookingMode", () => {
+  it("affiche les ingrédients associés à l'étape courante", async () => {
+    const user = userEvent.setup()
+    renderCookingMode()
+    await goToFirstStep(user)
+
+    const panel = screen.getByText("Pour cette étape").closest("div")!
+    expect(panel).toHaveTextContent("250")
+    expect(panel).toHaveTextContent("farine")
+    expect(panel).toHaveTextContent("œufs")
+    expect(panel).not.toHaveTextContent("lait")
+  })
+
+  it("n'affiche pas d'encart sur une étape sans ingrédients associés", async () => {
+    const user = userEvent.setup()
+    renderCookingMode()
+    await goToFirstStep(user)
+    await user.click(screen.getByRole("button", { name: "Suivant" }))
+
+    expect(screen.queryByText("Pour cette étape")).not.toBeInTheDocument()
+    expect(screen.getByText("Cuire à la poêle")).toBeInTheDocument()
+  })
+
+  it("met les quantités de l'étape à l'échelle des portions demandées", async () => {
+    const user = userEvent.setup()
+    renderCookingMode({ baseServings: 4, targetServings: 8 })
+    await goToFirstStep(user)
+
+    const panel = screen.getByText("Pour cette étape").closest("div")!
+    expect(panel).toHaveTextContent("500")
+    expect(panel).toHaveTextContent("6")
+  })
+
+  it("n'affiche aucun encart pour une recette sans associations", async () => {
+    const user = userEvent.setup()
+    renderCookingMode({
+      instructions: [{ id: "s1", text: "Tout mélanger" }],
+    })
+    await goToFirstStep(user)
+
+    expect(screen.queryByText("Pour cette étape")).not.toBeInTheDocument()
+  })
+})

--- a/src/presentation/components/CookingMode.tsx
+++ b/src/presentation/components/CookingMode.tsx
@@ -5,6 +5,7 @@ import { cn } from "../../lib/utils.ts"
 import type { MealieIngredient, MealieInstruction } from "../../shared/types/mealie.ts"
 import { MarkdownContent } from "./MarkdownContent.tsx"
 import { formatQuantity } from "../../shared/utils/servings.ts"
+import { ingredientsForInstruction } from "../../shared/utils/instructionIngredients.ts"
 
 interface CookingModeProps {
   recipeName: string
@@ -101,6 +102,8 @@ export function CookingMode({
               step={step + 1}
               total={totalSteps}
               instruction={currentInstruction!}
+              ingredients={ingredients}
+              servingsRatio={servingsRatio}
             />
           )}
         </div>
@@ -133,6 +136,43 @@ export function CookingMode({
   )
 }
 
+// ─── Ligne d'ingrédient ───────────────────────────────────────────────────────
+
+/** Ingrédient formaté, quantité mise à l'échelle des portions demandées. */
+function IngredientLine({
+  ingredient,
+  servingsRatio,
+  compact = false,
+}: {
+  ingredient: MealieIngredient
+  servingsRatio: number
+  compact?: boolean
+}) {
+  const scaledQuantity =
+    ingredient.quantity != null && ingredient.quantity !== 0
+      ? formatQuantity(ingredient.quantity * servingsRatio)
+      : null
+
+  return (
+    <li className={cn("flex items-baseline gap-2", compact ? "text-lg" : "text-xl")}>
+      <span
+        className={cn(
+          "shrink-0 rounded-full bg-primary",
+          compact ? "h-1.5 w-1.5 mt-2" : "h-2 w-2 mt-2.5",
+        )}
+      />
+      {scaledQuantity && <span className="font-semibold tabular-nums">{scaledQuantity}</span>}
+      {ingredient.unit?.name && <span className="text-muted-foreground">{ingredient.unit.name}</span>}
+      {ingredient.food?.name && <span className="font-medium">{ingredient.food.name}</span>}
+      {ingredient.note && (
+        <span className={cn("text-muted-foreground", compact ? "text-sm" : "text-base")}>
+          {" "}— {ingredient.note}
+        </span>
+      )}
+    </li>
+  )
+}
+
 // ─── Ingrédients screen ───────────────────────────────────────────────────────
 
 function IngredientsScreen({
@@ -162,25 +202,9 @@ function IngredientsScreen({
         )}
       </div>
       <ul className="space-y-4">
-        {filtered.map((ing, i) => {
-          const scaledQuantity =
-            ing.quantity != null && ing.quantity !== 0
-              ? formatQuantity(ing.quantity * servingsRatio)
-              : null
-          return (
-            <li key={i} className="flex items-baseline gap-2 text-xl">
-              <span className="h-2 w-2 shrink-0 rounded-full bg-primary mt-2.5" />
-              {scaledQuantity && (
-                <span className="font-semibold tabular-nums">{scaledQuantity}</span>
-              )}
-              {ing.unit?.name && (
-                <span className="text-muted-foreground">{ing.unit.name}</span>
-              )}
-              {ing.food?.name && <span className="font-medium">{ing.food.name}</span>}
-              {ing.note && <span className="text-muted-foreground text-base"> — {ing.note}</span>}
-            </li>
-          )
-        })}
+        {filtered.map((ing, i) => (
+          <IngredientLine key={i} ingredient={ing} servingsRatio={servingsRatio} />
+        ))}
       </ul>
     </div>
   )
@@ -192,11 +216,19 @@ function InstructionScreen({
   step,
   total,
   instruction,
+  ingredients,
+  servingsRatio,
 }: {
   step: number
   total: number
   instruction: MealieInstruction
+  ingredients: MealieIngredient[]
+  servingsRatio: number
 }) {
+  // Vide pour les recettes qui n'associent pas leurs ingrédients aux étapes :
+  // l'encart disparaît alors complètement.
+  const stepIngredients = ingredientsForInstruction(instruction, ingredients)
+
   return (
     <div className="space-y-8">
       <div className="flex items-center gap-4">
@@ -213,6 +245,19 @@ function InstructionScreen({
 
       {instruction.title && (
         <h3 className="font-heading text-2xl font-semibold">{instruction.title}</h3>
+      )}
+
+      {stepIngredients.length > 0 && (
+        <div className="rounded-[var(--radius-xl)] border border-border/60 bg-secondary/40 px-5 py-4">
+          <p className="mb-3 text-xs font-bold uppercase tracking-[0.12em] text-muted-foreground">
+            Pour cette étape
+          </p>
+          <ul className="space-y-2.5">
+            {stepIngredients.map((ing, i) => (
+              <IngredientLine key={i} ingredient={ing} servingsRatio={servingsRatio} compact />
+            ))}
+          </ul>
+        </div>
       )}
       <MarkdownContent className="text-2xl leading-relaxed text-foreground [&_p]:leading-relaxed [&_ul]:ml-6 [&_ol]:ml-6">
         {instruction.text ?? ""}

--- a/src/shared/types/mealie.ts
+++ b/src/shared/types/mealie.ts
@@ -38,10 +38,21 @@ export interface MealieIngredient {
   title?: string
 }
 
+/** Lien d'une étape vers un ingrédient de la recette (Mealie associe par `referenceId`). */
+export interface MealieIngredientReference {
+  referenceId: string
+}
+
 export interface MealieInstruction {
   id: string
   title?: string
+  summary?: string
   text: string
+  /**
+   * Ingrédients associés à l'étape dans Mealie. À préserver lors des PUT :
+   * réécrire une étape sans ce champ efface les associations côté serveur.
+   */
+  ingredientReferences?: MealieIngredientReference[]
 }
 
 export interface MealieCategory {

--- a/src/shared/utils/instructionIngredients.test.ts
+++ b/src/shared/utils/instructionIngredients.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import type { MealieIngredient, MealieInstruction } from "../types/mealie.ts"
+import { ingredientsForInstruction } from "./instructionIngredients.ts"
+
+const farine: MealieIngredient = { referenceId: "ref-1", quantity: 250, unit: { name: "g" }, food: { name: "farine" } }
+const oeufs: MealieIngredient = { referenceId: "ref-2", quantity: 3, food: { name: "œufs" } }
+const lait: MealieIngredient = { referenceId: "ref-3", quantity: 50, unit: { name: "cl" }, food: { name: "lait" } }
+const ingredients = [farine, oeufs, lait]
+
+function step(refs: string[]): MealieInstruction {
+  return {
+    id: "step-1",
+    text: "Mélanger",
+    ingredientReferences: refs.map((referenceId) => ({ referenceId })),
+  }
+}
+
+describe("ingredientsForInstruction", () => {
+  it("retourne les ingrédients référencés par l'étape", () => {
+    expect(ingredientsForInstruction(step(["ref-1", "ref-2"]), ingredients)).toEqual([farine, oeufs])
+  })
+
+  it("retourne une liste vide quand l'étape n'associe aucun ingrédient", () => {
+    expect(ingredientsForInstruction(step([]), ingredients)).toEqual([])
+  })
+
+  it("retourne une liste vide quand le champ est absent (recette sans associations)", () => {
+    expect(ingredientsForInstruction({ id: "s", text: "Cuire" }, ingredients)).toEqual([])
+  })
+
+  it("ignore une référence vers un ingrédient supprimé", () => {
+    expect(ingredientsForInstruction(step(["ref-1", "ref-inconnu"]), ingredients)).toEqual([farine])
+  })
+
+  it("suit l'ordre de la liste d'ingrédients, pas celui des références", () => {
+    const result = ingredientsForInstruction(step(["ref-3", "ref-1"]), ingredients)
+    expect(result).toEqual([farine, lait])
+  })
+
+  it("ignore les ingrédients sans referenceId", () => {
+    const libre: MealieIngredient = { note: "une pincée de sel" }
+    expect(ingredientsForInstruction(step(["ref-1"]), [...ingredients, libre])).toEqual([farine])
+  })
+})

--- a/src/shared/utils/instructionIngredients.ts
+++ b/src/shared/utils/instructionIngredients.ts
@@ -1,0 +1,24 @@
+import type { MealieIngredient, MealieInstruction } from "../types/mealie.ts"
+
+/**
+ * Ingrédients associés à une étape dans Mealie.
+ *
+ * Mealie relie les deux via `instruction.ingredientReferences[].referenceId`
+ * et `ingredient.referenceId`. Les recettes qui n'utilisent pas cette
+ * association renvoient une liste vide — l'appelant n'affiche alors rien.
+ *
+ * L'ordre suit celui de la liste d'ingrédients de la recette, pas celui des
+ * références, pour rester cohérent avec l'écran « Ingrédients ».
+ */
+export function ingredientsForInstruction(
+  instruction: MealieInstruction,
+  ingredients: MealieIngredient[],
+): MealieIngredient[] {
+  const referenced = new Set(
+    (instruction.ingredientReferences ?? [])
+      .map((ref) => ref.referenceId)
+      .filter(Boolean),
+  )
+  if (referenced.size === 0) return []
+  return ingredients.filter((ing) => ing.referenceId && referenced.has(ing.referenceId))
+}


### PR DESCRIPTION
Closes #38

## Problème

En mode cuisine, les ingrédients associés aux étapes dans Mealie n'apparaissaient nulle part après l'écran d'ouverture. Pour les recettes rédigées sans quantités en dur dans le texte — ce qui est justement recommandé pour bénéficier du système de portions — les slides devenaient inexploitables.

## Solution

Chaque slide d'étape affiche un encart **« Pour cette étape »** listant ses ingrédients, quantités mises à l'échelle des portions demandées comme sur l'écran d'ouverture. L'encart n'apparaît pas pour les recettes qui n'associent rien : aucun changement visible pour elles.

## Cause profonde corrigée au passage

`RecipeRepository.update()` réécrivait `recipeInstructions` avec seulement `{ id, text }`. Comme le PUT Mealie remplace la recette entière, **chaque sauvegarde depuis Bonap effaçait `title` et `ingredientReferences`** côté serveur — donc les associations faites dans Mealie ne survivaient pas à une édition Bonap. La fusion se fait désormais par `id` avec l'étape existante, comme c'était déjà le cas pour les ingrédients.

C'est la même famille de piège que le PUT shopping ; les deux sont maintenant documentés dans `CLAUDE.md`.

## Détails

- `MealieInstruction` porte `summary` et `ingredientReferences` (le type les ignorait, d'où la perte silencieuse).
- `ingredientsForInstruction()` (`shared/utils/instructionIngredients.ts`) fait la jointure `instruction.ingredientReferences[].referenceId` ↔ `ingredient.referenceId`, tolère les références orphelines et suit l'ordre de la liste d'ingrédients de la recette.
- `IngredientLine` factorise le rendu d'un ingrédient entre l'écran d'ouverture et l'encart (variante `compact`).

Le modèle de données a été vérifié sur une instance Mealie réelle avant implémentation.

**Hors périmètre** : créer l'association ingrédient ↔ étape se fait toujours dans Mealie, le formulaire Bonap ne l'édite pas — il ne l'écrase simplement plus.

## Vérifications

- `npx tsc -b --noEmit` — OK
- `npx eslint src/` — OK
- `npx vitest run` — 150 tests, 14 fichiers (+13 : jointure, rendu du mode cuisine avec Testing Library, préservation des étapes au PUT)
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)